### PR TITLE
fix: force left side context to be up-to-date

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -515,9 +515,11 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
     @MainActor
     func submitCandidate(_ candidate: Candidate) {
         if let client = self.client() {
+            // インサートを行う前にコンテキストを取得する
+            let cleanLeftSideContext = self.segmentsManager.getCleanLeftSideContext(maxCount: 30)
             client.insertText(candidate.text, replacementRange: NSRange(location: NSNotFound, length: 0))
             // アプリケーションサポートのディレクトリを準備しておく
-            self.segmentsManager.prefixCandidateCommited(candidate)
+            self.segmentsManager.prefixCandidateCommited(candidate, leftSideContext: cleanLeftSideContext ?? "")
         }
     }
 


### PR DESCRIPTION
#97 を修正

* getLeftSideContextの実行タイミングに依存しそうで嫌だったので、**getLeftSideContextを常にinsertの前に呼ぶ**ことで、**leftSideContextに確定された部分が含まれないこと**を保証した