### PR TITLE
feat: "Control + ;" works as F8

### DIFF
--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -84,6 +84,14 @@ extension UserAction {
             } else {
                 return .unknown
             }
+        case 0x29: // Control + ;
+            if event.modifierFlags.contains(.control) {
+                return .function(.eight)
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(keyMap(text))
+            } else {
+                return .unknown
+            }
         case 0x01: // Control + s
             if event.modifierFlags.contains(.control) {
                 return .suggest


### PR DESCRIPTION
`ctrl-j` でひらがな確定 (F6)、 `ctrl-k` でカタカナ確定 (F7)、というのがMac標準と同じでわかりやすくて助かっています。ほかのキーも同様に使えるようになるとなお良いと思いました。

- [x] `ctrl-j` ひらがな (F6)
- [x] `ctrl-k` カタカナ (F7)
- [ ] `ctrl-l` 全角英字 (F9)
- [ ] `ctrl-;` 英字 or 半角カナ (F8)
- [ ] `ctrl-:` 英字 (F10)
- [ ] `ctrl-'` 英字

これらのうち、F8相当のコードに当たりをつけて仮に書いてみたのが今回のPRで、動作確認もしておりません。このままマージしてほしいというよりは、こういうことを求めていますという例だと思ってください。現状ではF8が半角カナ決め打ちになっているようですが、英字も選択できるようになるとなお嬉しいです。

参照: <https://support.apple.com/ja-jp/guide/japanese-input-method/jpim10263/mac>
