### PR TITLE
refactor: update AZKKC to v0.8.0 and support Zenzai trait

### DIFF
--- a/Core/.gitignore
+++ b/Core/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Core",
+    platforms: [.macOS(.v13)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Core",
+            targets: ["Core"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "v0.8.0", traits: ["Zenzai"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Core",
+            dependencies: [
+                .product(name: "SwiftUtils", package: "AzooKeyKanaKanjiConverter"),
+                .product(name: "KanaKanjiConverterModuleWithDefaultDictionary", package: "AzooKeyKanaKanjiConverter"),
+            ]
+        ),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: ["Core"]
+        ),
+    ]
+)

--- a/Core/Sources/Core/Core.swift
+++ b/Core/Sources/Core/Core.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Core/Tests/CoreTests/CoreTests.swift
+++ b/Core/Tests/CoreTests/CoreTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Core
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -15,12 +15,11 @@
 		551434E72D576B6600A9B5CA /* lm_r_xbx.marisa in Resources */ = {isa = PBXBuildFile; fileRef = 551434E22D576B6600A9B5CA /* lm_r_xbx.marisa */; };
 		551434E82D576B6600A9B5CA /* lm_c_abc.marisa in Resources */ = {isa = PBXBuildFile; fileRef = 551434E12D576B6600A9B5CA /* lm_c_abc.marisa */; };
 		551434EA2D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 551434E92D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf */; };
+		554A26602DB37657003C5CFB /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 554A265F2DB37657003C5CFB /* Core */; };
 		556C52FB2BAAAF7E00EB343F /* en.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52F92BAAAF7D00EB343F /* en.tiff */; };
 		556C52FC2BAAAF7E00EB343F /* en@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52FA2BAAAF7D00EB343F /* en@2x.tiff */; };
 		55A27D022BAAADDB00512DCD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 55A27D002BAAADDB00512DCD /* InfoPlist.strings */; };
 		55A9C54B2BA847A1007F6F02 /* main@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 55A9C54A2BA847A1007F6F02 /* main@2x.tiff */; };
-		55E0A5BE2BA8AE3200FACF50 /* KanaKanjiConverterModuleWithDefaultDictionary in Frameworks */ = {isa = PBXBuildFile; productRef = 55E0A5BD2BA8AE3200FACF50 /* KanaKanjiConverterModuleWithDefaultDictionary */; };
-		55E0A5C02BA8AE3200FACF50 /* SwiftUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 55E0A5BF2BA8AE3200FACF50 /* SwiftUtils */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +57,7 @@
 		556C52FA2BAAAF7D00EB343F /* en@2x.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "en@2x.tiff"; sourceTree = "<group>"; };
 		55A27D012BAAADDB00512DCD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		55A9C54A2BA847A1007F6F02 /* main@2x.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "main@2x.tiff"; sourceTree = "<group>"; };
+		55D3B7632DB36BDE00044FD1 /* Core */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Core; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -76,8 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55E0A5C02BA8AE3200FACF50 /* SwiftUtils in Frameworks */,
-				55E0A5BE2BA8AE3200FACF50 /* KanaKanjiConverterModuleWithDefaultDictionary in Frameworks */,
+				554A26602DB37657003C5CFB /* Core in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,6 +100,7 @@
 		1A41E60B26E745D9009B65D7 = {
 			isa = PBXGroup;
 			children = (
+				55D3B7632DB36BDE00044FD1 /* Core */,
 				1A41E61626E745D9009B65D7 /* azooKeyMac */,
 				55CE06ED2CB01F160002DAF1 /* azooKeyMacTests */,
 				55CE06F12CB01F160002DAF1 /* azooKeyMacUITests */,
@@ -167,6 +167,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				554A26622DB3765F003C5CFB /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				55CE06C72CB01F000002DAF1 /* InputController */,
@@ -178,8 +179,7 @@
 			);
 			name = azooKeyMac;
 			packageProductDependencies = (
-				55E0A5BD2BA8AE3200FACF50 /* KanaKanjiConverterModuleWithDefaultDictionary */,
-				55E0A5BF2BA8AE3200FACF50 /* SwiftUtils */,
+				554A265F2DB37657003C5CFB /* Core */,
 			);
 			productName = azooKeyMac;
 			productReference = 1A41E61426E745D9009B65D7 /* azooKeyMac.app */;
@@ -260,7 +260,7 @@
 			);
 			mainGroup = 1A41E60B26E745D9009B65D7;
 			packageReferences = (
-				55E0A5BA2BA8AE3200FACF50 /* XCRemoteSwiftPackageReference "AzooKeyKanaKanjiConverter" */,
+				554A265E2DB37657003C5CFB /* XCLocalSwiftPackageReference "Core" */,
 			);
 			productRefGroup = 1A41E61526E745D9009B65D7 /* Products */;
 			projectDirPath = "";
@@ -343,6 +343,10 @@
 			isa = PBXTargetDependency;
 			target = 1A41E61326E745D9009B65D7 /* azooKeyMac */;
 			targetProxy = 1A41E62F26E745DD009B65D7 /* PBXContainerItemProxy */;
+		};
+		554A26622DB3765F003C5CFB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 554A26612DB3765F003C5CFB /* Core */;
 		};
 /* End PBXTargetDependency section */
 
@@ -683,27 +687,22 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		55E0A5BA2BA8AE3200FACF50 /* XCRemoteSwiftPackageReference "AzooKeyKanaKanjiConverter" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ensan-hcl/AzooKeyKanaKanjiConverter";
-			requirement = {
-				kind = revision;
-				revision = c6a9812549a01aa7ef3be8e3523798187e06b335;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		554A265E2DB37657003C5CFB /* XCLocalSwiftPackageReference "Core" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Core;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		55E0A5BD2BA8AE3200FACF50 /* KanaKanjiConverterModuleWithDefaultDictionary */ = {
+		554A265F2DB37657003C5CFB /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 55E0A5BA2BA8AE3200FACF50 /* XCRemoteSwiftPackageReference "AzooKeyKanaKanjiConverter" */;
-			productName = KanaKanjiConverterModuleWithDefaultDictionary;
+			productName = Core;
 		};
-		55E0A5BF2BA8AE3200FACF50 /* SwiftUtils */ = {
+		554A26612DB3765F003C5CFB /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 55E0A5BA2BA8AE3200FACF50 /* XCRemoteSwiftPackageReference "AzooKeyKanaKanjiConverter" */;
-			productName = SwiftUtils;
+			package = 554A265E2DB37657003C5CFB /* XCLocalSwiftPackageReference "Core" */;
+			productName = Core;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
* AzooKeyKanaKanjiConverterのバージョンをv0.8.0に更新
* Swift 6.1で導入されたSwift Package Traitsを利用できるよう、Swift PackageをXcodeproj内に追加
* 以降はこのSwift Package内にロジック・テストを移動する