### PR TITLE
feat: add ci for testing `Core` and check the build-ability

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           brew update
           brew install swiftlint
+      - name: Check SwiftLint version
+        run: swiftlint version
       - name: Run SwiftLint
         run: |
           swiftlint --fix --format

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,51 @@
+name: Swift Build and Test
+on:
+  push:
+  pull_request:
+
+jobs:
+  macos-build:
+    name: Build and Test on macOS
+    runs-on: macos-latest
+    steps:
+      - uses: swift-actions/setup-swift@v2.3.0
+        with:
+          swift-version: 6.1
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Build
+        run: swift build --package-path Core
+      - name: Test
+        run: swift test --package-path Core
+
+  xcodebuild-test:
+    name: Xcodebuild test on macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Verify xcodebuild installation
+        run: xcodebuild -version
+      - name: List available schemes
+        run: xcodebuild -project azooKeyMac.xcodeproj -list
+      - name: Test building azooKeyMac (Release configuration)
+        run: xcodebuild -project azooKeyMac.xcodeproj -scheme azooKeyMac -configuration Release -quiet build
+
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install SwiftLint
+        run: |
+          brew update
+          brew install swiftlint
+      - name: Run SwiftLint
+        run: |
+          swiftlint --fix --format
+          swiftlint --quiet --strict
+  

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,9 +8,12 @@ jobs:
     name: Build and Test on macOS
     runs-on: macos-15
     steps:
-      - uses: swift-actions/setup-swift@v2.3.0
-        with:
-          swift-version: 6.1
+      - name: Select Xcode 16.3
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_16.3*.app | head -n 1)
+          echo "Using Xcode at $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+          xcodebuild -version
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -23,6 +26,12 @@ jobs:
     name: Xcodebuild test on macOS
     runs-on: macos-15
     steps:
+      - name: Select Xcode 16.3
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_16.3*.app | head -n 1)
+          echo "Using Xcode at $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+          xcodebuild -version
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,7 +40,8 @@ jobs:
       - name: List available schemes
         run: xcodebuild -project azooKeyMac.xcodeproj -list
       - name: Test building azooKeyMac (Release configuration)
-        run: xcodebuild \
+        run: |
+         xcodebuild \
           -project azooKeyMac.xcodeproj \
           -scheme azooKeyMac \
           -configuration Release \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   macos-build:
     name: Build and Test on macOS
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: swift-actions/setup-swift@v2.3.0
         with:
@@ -21,7 +21,7 @@ jobs:
 
   xcodebuild-test:
     name: Xcodebuild test on macOS
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
 
   swiftlint:
     name: SwiftLint
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,7 +40,14 @@ jobs:
       - name: List available schemes
         run: xcodebuild -project azooKeyMac.xcodeproj -list
       - name: Test building azooKeyMac (Release configuration)
-        run: xcodebuild -project azooKeyMac.xcodeproj -scheme azooKeyMac -configuration Release -quiet build
+        run: xcodebuild \
+          -project azooKeyMac.xcodeproj \
+          -scheme azooKeyMac \
+          -configuration Release \
+          -destination 'generic/platform=macOS' \
+          CODE_SIGNING_ALLOWED=NO \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGN_IDENTITY=""
 
   swiftlint:
     name: SwiftLint

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -420,7 +420,6 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SYMROOT = build;
 			};
 			name = Debug;
 		};
@@ -478,7 +477,6 @@
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SYMROOT = build;
 			};
 			name = Release;
 		};

--- a/azooKeyMac/Extensions/KeychainHelper.swift
+++ b/azooKeyMac/Extensions/KeychainHelper.swift
@@ -33,7 +33,7 @@ enum KeychainHelper {
         let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
 
         if status == errSecSuccess, let data = dataTypeRef as? Data {
-            return String(decoding: data, as: UTF8.self)
+            return String(bytes: data, encoding: .utf8)
         }
 
         return nil

--- a/azooKeyMac/InputController/OpenAIClient.swift
+++ b/azooKeyMac/InputController/OpenAIClient.swift
@@ -271,7 +271,7 @@ enum OpenAIClient {
         }
 
         guard httpResponse.statusCode == 200 else {
-            let responseBody = String(decoding: data, as: UTF8.self)
+            let responseBody = String(bytes: data, encoding: .utf8) ?? "Body is not encoded in UTF-8"
             throw OpenAIError.invalidResponseStatus(code: httpResponse.statusCode, body: responseBody)
         }
 


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for Swift development, updates build settings in the Xcode project, and improves string decoding in the codebase. These changes enhance CI/CD processes, streamline project configuration, and improve error handling.

### CI/CD Enhancements:
Added a new GitHub Actions workflow (`.github/workflows/swift.yml`) that includes jobs for building and testing on macOS, running `xcodebuild` tests, and enforcing SwiftLint for code quality.

### Xcode Project Configuration:
* Removed the `SYMROOT` setting from both the Debug and Release build configurations in `azooKeyMac.xcodeproj/project.pbxproj`, allowing Xcode to use its default build directory. [[1]](diffhunk://#diff-e74651d5be8fe0e64f4081b0a15095d033917265749205b74902cda6ff36012bL423) [[2]](diffhunk://#diff-e74651d5be8fe0e64f4081b0a15095d033917265749205b74902cda6ff36012bL481)

### Code Improvements:
* Updated string decoding in `KeychainHelper` to use `String(bytes:encoding:)` for better handling of UTF-8 encoded data.
* Improved error handling in `OpenAIClient` by using `String(bytes:encoding:)` with a fallback message for non-UTF-8 encoded response bodies.