### PR TITLE
feat: 「スペースは常に半角を入力」をオンにすると、半角スペースを優先するようにしました

### DIFF
--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -2,7 +2,7 @@ public enum UserAction {
     case input(String)
     case backspace
     case enter
-    case space
+    case space(Bool)
     case escape
     case tab
     case unknown

--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -2,7 +2,7 @@ public enum UserAction {
     case input(String)
     case backspace
     case enter
-    case space(Bool)
+    case space(prefersFullWidthWhenInput: Bool)
     case escape
     case tab
     case unknown

--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -71,12 +71,11 @@ public enum InputState: Sendable, Hashable {
                 return (.selectInputLanguage(.japanese), .fallthrough)
             case .英数:
                 return (.selectInputLanguage(.english), .fallthrough)
-            case .space:
-                // Shift+Spaceでは半角スペースを入力
-                if inputLanguage == .english || event.modifierFlags.contains(.shift) {
-                    return (.insertWithoutMarkedText(" "), .fallthrough)
-                } else {
+            case .space(let isFullSpace):
+                if inputLanguage != .english && isFullSpace {
                     return (.insertWithoutMarkedText("　"), .fallthrough)
+                } else {
+                    return (.insertWithoutMarkedText(" "), .fallthrough)
                 }
             case .suggest:
                 if enableSuggestion {

--- a/azooKeyMac/Configs/BoolConfigItem.swift
+++ b/azooKeyMac/Configs/BoolConfigItem.swift
@@ -40,6 +40,11 @@ extension Config {
         static let `default` = false
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.typeCommaAndPeriod"
     }
+    /// 「　」の代わりに「 」を入力する設定
+    struct TypeHalfSpace: BoolConfigItem {
+        static let `default` = false
+        static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.typeHalfSpace"
+    }
     /// Zenzaiを利用する設定
     struct ZenzaiIntegration: BoolConfigItem {
         static let `default` = true

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -110,7 +110,7 @@ extension UserAction {
             case (true, true), (false, false):
                 // 全角スペース
                 return .space(true)
-            default:
+            case (true, false), (false, true):
                 return .space(false)
             }
         case 51: // Delete

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -106,7 +106,13 @@ extension UserAction {
         case 48: // Tab
             return .tab
         case 49: // Space
-            return .space
+            switch (Config.TypeHalfSpace().value, event.modifierFlags.contains(.shift)) {
+            case (true, true), (false, false):
+                // 全角スペース
+                return .space(true)
+            default:
+                return .space(false)
+            }
         case 51: // Delete
             return .backspace
         case 53: // Escape

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -109,9 +109,9 @@ extension UserAction {
             switch (Config.TypeHalfSpace().value, event.modifierFlags.contains(.shift)) {
             case (true, true), (false, false):
                 // 全角スペース
-                return .space(true)
+                return .space(prefersFullWidthWhenInput: true)
             case (true, false), (false, true):
-                return .space(false)
+                return .space(prefersFullWidthWhenInput: false)
             }
         case 51: // Delete
             return .backspace

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -5,6 +5,7 @@ struct ConfigWindow: View {
     @ConfigState private var liveConversion = Config.LiveConversion()
     @ConfigState private var typeBackSlash = Config.TypeBackSlash()
     @ConfigState private var typeCommaAndPeriod = Config.TypeCommaAndPeriod()
+    @ConfigState private var typeHalfSpace = Config.TypeHalfSpace()
     @ConfigState private var zenzai = Config.ZenzaiIntegration()
     @ConfigState private var zenzaiProfile = Config.ZenzaiProfile()
     @ConfigState private var zenzaiPersonalizationLevel = Config.ZenzaiPersonalizationLevel()
@@ -98,6 +99,7 @@ struct ConfigWindow: View {
                         Toggle("ライブ変換を有効化", isOn: $liveConversion)
                         Toggle("円記号の代わりにバックスラッシュを入力", isOn: $typeBackSlash)
                         Toggle("「、」「。」の代わりに「，」「．」を入力", isOn: $typeCommaAndPeriod)
+                        Toggle("スペースは常に半角を入力", isOn: $typeHalfSpace)
                         Divider()
                         Button("ユーザ辞書を編集する") {
                             (NSApplication.shared.delegate as? AppDelegate)!.openUserDictionaryEditorWindow()


### PR DESCRIPTION
Google日本語入力では以下のような設定があり、設定値を「半角」にすると、日本語入力モードにおいてスペースを入力した際でも「半角スペース」が入力されるようになります。ちなみにShift+Spaceだと全角スペースになります。

<img width="495" alt="image" src="https://github.com/user-attachments/assets/02664490-4193-4e84-99c5-35ece85bff6a" />

この設定と同等の内容になるような設定項目を追加しました。
個人的に、全角スペースを入力することがあまりないのでこの設定を有効にしていることと、Discordを覗いてみたら要望があったのであるといいのかなと思って追加させてもらいました。

## コードに関して

InputState.swiftではConfigが読めるようになってなさそうだったので、UserActionで切り替えできるようにしました。

今回、`space`を`space(Bool)`にしています。最初、`fullSpace`というのを増やそうと思ったんですが、InputState.swiftの分岐の中で`space`が何度か登場しているので、`space(Bool)`のほうがシンプルにできそうと判断してこのようにしました。初見だと「`space(Bool)`のBoolってなんじゃ？」ってなりそうなのが微妙なところですが。
