### PR TITLE
feat: 全角数字をまとめて変換できるように

### DIFF
--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -128,6 +128,7 @@ final class SegmentsManager {
             requireEnglishPrediction: false,
             keyboardLanguage: .ja_JP,
             englishCandidateInRoman2KanaInput: false,
+            fullWidthRomanCandidate: true,
             learningType: Config.Learning().value.learningType,
             memoryDirectoryURL: self.azooKeyMemoryDir,
             sharedContainerURL: self.azooKeyMemoryDir,


### PR DESCRIPTION
タイピングゲームをやるときに全角数字に変換できなくて困るので、全角数字をまとめて変換できるようにした。
https://sanarome-typing.com/kanji-henkan-typing/