### PR TITLE
Improve menu bar UI clarity for Zenzai and Live Conversion settings

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -5,7 +5,7 @@ extension azooKeyMacInputController {
     // MARK: - Settings and Menu Items
 
     func setupMenu() {
-        self.zenzaiToggleMenuItem = NSMenuItem(title: "Zenzai（ニューラル変換）", action: #selector(self.toggleZenzai(_:)), keyEquivalent: "")
+        self.zenzaiToggleMenuItem = NSMenuItem(title: "Zenzai（ニューラルかな漢字変換）", action: #selector(self.toggleZenzai(_:)), keyEquivalent: "")
         self.liveConversionToggleMenuItem = NSMenuItem(title: "ライブ変換", action: #selector(self.toggleLiveConversion(_:)), keyEquivalent: "")
         self.appMenu.addItem(self.zenzaiToggleMenuItem)
         self.appMenu.addItem(self.liveConversionToggleMenuItem)

--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -23,7 +23,7 @@ extension azooKeyMacInputController {
 
     func updateZenzaiToggleMenuItem(newValue: Bool) {
         self.zenzaiToggleMenuItem.state = newValue ? .on : .off
-        self.zenzaiToggleMenuItem.title = "Zenzai（ニューラルかな変換）"
+        self.zenzaiToggleMenuItem.title = "Zenzai（ニューラルかな漢字変換）"
     }
 
     @objc func toggleLiveConversion(_ sender: Any) {

--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -23,7 +23,7 @@ extension azooKeyMacInputController {
 
     func updateZenzaiToggleMenuItem(newValue: Bool) {
         self.zenzaiToggleMenuItem.state = newValue ? .on : .off
-        self.zenzaiToggleMenuItem.title = "Zenzai（ニューラル変換）"
+        self.zenzaiToggleMenuItem.title = "Zenzai（ニューラルかな変換）"
     }
 
     @objc func toggleLiveConversion(_ sender: Any) {

--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -5,10 +5,11 @@ extension azooKeyMacInputController {
     // MARK: - Settings and Menu Items
 
     func setupMenu() {
-        self.zenzaiToggleMenuItem = NSMenuItem(title: "ZenzaiをOFF", action: #selector(self.toggleZenzai(_:)), keyEquivalent: "")
-        self.liveConversionToggleMenuItem = NSMenuItem(title: "ライブ変換をOFF", action: #selector(self.toggleLiveConversion(_:)), keyEquivalent: "")
+        self.zenzaiToggleMenuItem = NSMenuItem(title: "Zenzai（ニューラル変換）", action: #selector(self.toggleZenzai(_:)), keyEquivalent: "")
+        self.liveConversionToggleMenuItem = NSMenuItem(title: "ライブ変換", action: #selector(self.toggleLiveConversion(_:)), keyEquivalent: "")
         self.appMenu.addItem(self.zenzaiToggleMenuItem)
         self.appMenu.addItem(self.liveConversionToggleMenuItem)
+        self.appMenu.addItem(NSMenuItem.separator())
         self.appMenu.addItem(NSMenuItem(title: "詳細設定を開く", action: #selector(self.openConfigWindow(_:)), keyEquivalent: ""))
         self.appMenu.addItem(NSMenuItem(title: "View on GitHub", action: #selector(self.openGitHubRepository(_:)), keyEquivalent: ""))
     }
@@ -21,11 +22,8 @@ extension azooKeyMacInputController {
     }
 
     func updateZenzaiToggleMenuItem(newValue: Bool) {
-        self.zenzaiToggleMenuItem.title = if newValue {
-            "ZenzaiをOFF"
-        } else {
-            "ZenzaiをON"
-        }
+        self.zenzaiToggleMenuItem.state = newValue ? .on : .off
+        self.zenzaiToggleMenuItem.title = "Zenzai（ニューラル変換）"
     }
 
     @objc func toggleLiveConversion(_ sender: Any) {
@@ -36,7 +34,8 @@ extension azooKeyMacInputController {
     }
 
     func updateLiveConversionToggleMenuItem(newValue: Bool) {
-        self.liveConversionToggleMenuItem.title = newValue ? "ライブ変換をOFF" : "ライブ変換をON"
+        self.liveConversionToggleMenuItem.state = newValue ? .on : .off
+        self.liveConversionToggleMenuItem.title = "ライブ変換"
     }
 
     @objc func openGitHubRepository(_ sender: Any) {


### PR DESCRIPTION
- 現在の状態を示す「ZenzaiをOFF」「ZenzaiをON」のテキストを、チェックマーク（✓ = 有効、チェックなし = 無効）による明確な状態表示に変更
- 設定項目とその他のメニューオプションの間に視覚的な区切り線を追加してグループ化を改善
- ユーザーが現在どの機能が有効になっているかを一目で確認できるようにしました

![CleanShot 2025-05-29 at 22 32 41@2x](https://github.com/user-attachments/assets/9cf54d4d-6574-45e6-af3d-16fa6bb03994)

![CleanShot 2025-05-29 at 22 33 10@2x](https://github.com/user-attachments/assets/553e450f-44fb-4935-8a40-e903d7ae249f)
