### PR TITLE
feat: 「この候補の学習をリセット」機能を導入

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.8.0", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "a6e35f91acd873a579ee76211988de573b7bed53", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
@@ -40,6 +40,9 @@ public enum ClientAction {
     case enableDebugWindow
     case disableDebugWindow
 
+    /// 学習のリセット
+    case forgetMemory
+
     // Fnキーでの変換
     case submitKatakanaCandidate
     case submitHiraganaCandidate

--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -13,6 +13,7 @@ public enum UserAction {
     case number(Number)
     case editSegment(Int)
     case suggest
+    case forget
 
     public enum NavigationDirection: Sendable, Equatable, Hashable {
         case up, down, right, left

--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -83,7 +83,7 @@ public enum InputState: Sendable, Hashable {
                 } else {
                     return (.fallthrough, .fallthrough)
                 }
-            case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment, .tab:
+            case .unknown, .navigation, .backspace, .enter, .escape, .function, .editSegment, .tab, .forget:
                 return (.fallthrough, .fallthrough)
             }
         case .composing:
@@ -136,7 +136,7 @@ public enum InputState: Sendable, Hashable {
                 } else {
                     return (.fallthrough, .fallthrough)
                 }
-            case .unknown, .tab:
+            case .forget, .unknown, .tab:
                 return (.fallthrough, .fallthrough)
             }
         case .previewing:
@@ -179,7 +179,7 @@ public enum InputState: Sendable, Hashable {
                 }
             case .editSegment(let count):
                 return (.editSegment(count), .transition(.selecting))
-            case .unknown, .suggest, .tab:
+            case .unknown, .suggest, .tab, .forget:
                 return (.fallthrough, .fallthrough)
             }
         case .selecting:
@@ -242,6 +242,8 @@ public enum InputState: Sendable, Hashable {
                 }
             case .editSegment(let count):
                 return (.editSegment(count), .transition(.selecting))
+            case .forget:
+                return (.forgetMemory, .fallthrough)
             case .かな:
                 return (.consume, .fallthrough)
             case .英数:

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -247,6 +247,14 @@ final class SegmentsManager {
         self.updateRawCandidate()
     }
 
+    @MainActor
+    func forgetMemory() {
+        if let selectedCandidate {
+            self.kanaKanjiConverter.sendToDicdataStore(.forgetMemory(selectedCandidate))
+            self.appendDebugMessage("\(#function): forget \(selectedCandidate.data.map {$0.word})")
+        }
+    }
+
     private var candidates: [Candidate]? {
         if let rawCandidates {
             if !self.didExperienceSegmentEdition {

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -114,7 +114,11 @@ extension UserAction {
                 return .space(prefersFullWidthWhenInput: false)
             }
         case 51: // Delete
-            return .backspace
+            if event.modifierFlags.contains(.control) {
+                return .forget
+            } else {
+                return .backspace
+            }
         case 53: // Escape
             return .escape
         case 93: // Yen

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -230,6 +230,8 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
             self.segmentsManager.requestDebugWindowMode(enabled: false)
         case .stopComposition:
             self.segmentsManager.stopComposition()
+        case .forgetMemory:
+            self.segmentsManager.forgetMemory()
         case .selectInputLanguage(let language):
             self.inputLanguage = language
             self.switchInputLanguage(language, client: client)


### PR DESCRIPTION
iOS版でも導入済みの「この候補の学習をリセット」の機能をひっそり導入する。
* 変換候補を選択する際、選択した状態で`^⌫`で利用できる。これはGoogle日本語入力の初期設定と同様のコマンド。
* ただし、現状特に視覚的なフィードバックなどは付けていないので、見て分かるものではない。
* 視覚的なフィードバックは後回しで、一応サポート、という感じでやっていきたい