### PR TITLE
feat: 背景のマテリアルをより明るいものに変更し、文字サイズを大きくし、縦方向の余白を少し広げた

### DIFF
--- a/azooKeyMac/InputController/CandidateWindow/BaseCandidateViewController.swift
+++ b/azooKeyMac/InputController/CandidateWindow/BaseCandidateViewController.swift
@@ -12,7 +12,7 @@ class CandidateTableCellView: NSTableCellView {
 
     override init(frame frameRect: NSRect) {
         self.candidateTextField = NSTextField(labelWithString: "")
-        self.candidateTextField.font = NSFont.systemFont(ofSize: 16)
+        self.candidateTextField.font = NSFont.systemFont(ofSize: 18)
         super.init(frame: frameRect)
         self.addSubview(self.candidateTextField)
 
@@ -36,7 +36,7 @@ class CandidateTableCellView: NSTableCellView {
 
     override var backgroundStyle: NSView.BackgroundStyle {
         didSet {
-            candidateTextField.textColor = backgroundStyle == .emphasized ? .white : .textColor
+            candidateTextField.textColor = backgroundStyle == .emphasized ? .white : NSAppearance.currentDrawing().name == .aqua ? .init(white: 0.3, alpha: 1.0) : .textColor
         }
     }
 }
@@ -54,7 +54,7 @@ class BaseCandidateViewController: NSViewController {
         // Material View（背景）
         let materialView = NSVisualEffectView()
         materialView.blendingMode = .behindWindow
-        materialView.material = .underWindowBackground
+        materialView.material = .windowBackground
         materialView.state = .active
         materialView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -96,6 +96,7 @@ class BaseCandidateViewController: NSViewController {
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.tableView.selectionHighlightStyle = .regular
+        self.tableView.rowHeight = 28
 
         self.view = containerView
     }
@@ -181,7 +182,7 @@ class BaseCandidateViewController: NSViewController {
         return newWindowFrame
     }
 
-    func getMaxTextWidth(candidates: some Sequence<String>, font: NSFont = .systemFont(ofSize: 16)) -> CGFloat {
+    func getMaxTextWidth(candidates: some Sequence<String>, font: NSFont = .systemFont(ofSize: 18)) -> CGFloat {
         candidates.reduce(0) { maxWidth, candidate in
             let attributedString = NSAttributedString(
                 string: candidate,


### PR DESCRIPTION
followup: #150 

* マテリアルをより明るいもの（標準IMEに近いもの）に変更
* 文字サイズを16→18に拡大
* 文字色を30%のグレーに変更（標準IMEと揃えた）
* 縦方向の余白を広げた（やや見栄えが良くなる）

![image](https://github.com/user-attachments/assets/925b383b-674a-465a-bcf9-69d31987db55)
