### PR TITLE
fix: 変換確定に英数キーを使用すると入力が消える

### DIFF
--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -104,8 +104,8 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
             if let client = sender as? IMKTextInput {
                 client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
             }
-            self.refreshMarkedText() // クライアントのmarkedTextを確実にクリア
             self.inputState = .none // 状態をリセット
+            self.refreshMarkedText() // クライアントのmarkedTextを確実にクリア
         }
         self.segmentsManager.deactivate()
         self.candidatesWindow.orderOut(nil)

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -98,13 +98,19 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
 
     @MainActor
     override func deactivateServer(_ sender: Any!) {
+        // 未確定テキストが残っている場合は確定させる
+        if !self.segmentsManager.isEmpty {
+            let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
+            if let client = sender as? IMKTextInput {
+                client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+            self.refreshMarkedText() // クライアントのmarkedTextを確実にクリア
+            self.inputState = .none // 状態をリセット
+        }
         self.segmentsManager.deactivate()
         self.candidatesWindow.orderOut(nil)
         self.replaceSuggestionWindow.orderOut(nil)
         self.candidatesViewController.updateCandidates([], selectionIndex: nil, cursorLocation: .zero)
-        if let client = sender as? IMKTextInput {
-            client.insertText("", replacementRange: .notFound)
-        }
         super.deactivateServer(sender)
     }
 


### PR DESCRIPTION
英数キーを用いて macOS 標準の入力ソースへ切り替える時に、azooKey で入力中の未確定テキスト(Marked Text)が失われる問題を修正しました。

## 原因
以下の入力ソースの組み合わせにおいて、当不具合が発生していました。
- com.apple.keylayout.ABC
- dev.ensan.inputmethod.azooKeyMac.Japanese

日本語入力中に英数キーが押下されると、 azooKey のキーイベント処理よりも早く deactivateServer メソッドが呼び出されます。この deactivateServer 内で強制的に空文字列を挿入していたため、ユーザーが入力中の未確定テキストが消去されてしまう事象が発生していました。

## 変更内容
deactivateServer メソッドが呼び出された際に、segmentsManager に未確定テキストが存在する場合、そのテキストを確定するように変更しました。
入力フィールドがないアプリへの切り替えなどでdeactivateServerが呼び出された時に、未確定状態が意図せず残らないように、入力状態をリセットしてIM内部をクリーンに保ちます。

関連 Issue: #138