### PR TITLE
feat: Add dead keys to azooKey (English) Input Source

### DIFF
--- a/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
@@ -62,6 +62,12 @@ public enum ClientAction {
     case showPromptInputWindow
     case transformSelectedText(String, String)  // (selectedText, prompt)
 
+    // DeadKey handling
+    case setMarkedTextAndTransition(String, InputState)
+    case commitMarkedTextAndReplaceWith(String)
+    case commitMarkedTextAndThenInsert(String)
+    case stopCompositionAndSelectInputLanguage(InputLanguage)
+
     case stopComposition
 }
 

--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -15,6 +15,7 @@ public enum UserAction {
     case suggest
     case forget
     case transformSelectedText
+    case deadKey(String)
 
     public enum NavigationDirection: Sendable, Equatable, Hashable {
         case up, down, right, left

--- a/Core/Sources/Core/InputUtils/DeadKeyComposer.swift
+++ b/Core/Sources/Core/InputUtils/DeadKeyComposer.swift
@@ -1,0 +1,64 @@
+public struct DeadKeyComposer {
+    // Defines a struct to hold dead key mappings
+    struct Combination: Hashable {
+        let deadKey: String
+        let combiningChar: String
+        let lowercasedResult: String
+        let uppercasedResult: String
+    }
+
+    // Defines dead key combinations as a static property
+    static let combinations: Set<Combination> = [
+        // Umlaut (¨)
+        .init(deadKey: "¨", combiningChar: "a", lowercasedResult: "ä", uppercasedResult: "Ä"),
+        .init(deadKey: "¨", combiningChar: "e", lowercasedResult: "ë", uppercasedResult: "Ë"),
+        .init(deadKey: "¨", combiningChar: "i", lowercasedResult: "ï", uppercasedResult: "Ï"),
+        .init(deadKey: "¨", combiningChar: "o", lowercasedResult: "ö", uppercasedResult: "Ö"),
+        .init(deadKey: "¨", combiningChar: "u", lowercasedResult: "ü", uppercasedResult: "Ü"),
+        .init(deadKey: "¨", combiningChar: "y", lowercasedResult: "ÿ", uppercasedResult: "Ÿ"),
+        // Acute (´)
+        .init(deadKey: "´", combiningChar: "a", lowercasedResult: "á", uppercasedResult: "Á"),
+        .init(deadKey: "´", combiningChar: "e", lowercasedResult: "é", uppercasedResult: "É"),
+        .init(deadKey: "´", combiningChar: "i", lowercasedResult: "í", uppercasedResult: "Í"),
+        .init(deadKey: "´", combiningChar: "o", lowercasedResult: "ó", uppercasedResult: "Ó"),
+        .init(deadKey: "´", combiningChar: "u", lowercasedResult: "ú", uppercasedResult: "Ú"),
+        .init(deadKey: "´", combiningChar: "y", lowercasedResult: "ý", uppercasedResult: "Ý"),
+        // Grave (`)
+        .init(deadKey: "`", combiningChar: "a", lowercasedResult: "à", uppercasedResult: "À"),
+        .init(deadKey: "`", combiningChar: "e", lowercasedResult: "è", uppercasedResult: "È"),
+        .init(deadKey: "`", combiningChar: "i", lowercasedResult: "ì", uppercasedResult: "Ì"),
+        .init(deadKey: "`", combiningChar: "o", lowercasedResult: "ò", uppercasedResult: "Ò"),
+        .init(deadKey: "`", combiningChar: "u", lowercasedResult: "ù", uppercasedResult: "Ù"),
+        // Circumflex (ˆ)
+        .init(deadKey: "ˆ", combiningChar: "a", lowercasedResult: "â", uppercasedResult: "Â"),
+        .init(deadKey: "ˆ", combiningChar: "e", lowercasedResult: "ê", uppercasedResult: "Ê"),
+        .init(deadKey: "ˆ", combiningChar: "i", lowercasedResult: "î", uppercasedResult: "Î"),
+        .init(deadKey: "ˆ", combiningChar: "o", lowercasedResult: "ô", uppercasedResult: "Ô"),
+        .init(deadKey: "ˆ", combiningChar: "u", lowercasedResult: "û", uppercasedResult: "Û"),
+        // Tilde (˜)
+        .init(deadKey: "˜", combiningChar: "a", lowercasedResult: "ã", uppercasedResult: "Ã"),
+        .init(deadKey: "˜", combiningChar: "n", lowercasedResult: "ñ", uppercasedResult: "Ñ"),
+        .init(deadKey: "˜", combiningChar: "o", lowercasedResult: "õ", uppercasedResult: "Õ"),
+    ]
+
+    public struct DeadKeyInfo: Sendable {
+        public let deadKeyChar: String
+    }
+
+    public static let deadKeyList: [UInt16: DeadKeyInfo] = [
+        0x20: DeadKeyInfo(deadKeyChar: "¨"), // 'u'
+        0x0e: DeadKeyInfo(deadKeyChar: "´"), // 'e'
+        0x32: DeadKeyInfo(deadKeyChar: "`"), // '`' (US layout)
+        0x5e: DeadKeyInfo(deadKeyChar: "`"), // '_' (JIS layout)
+        0x22: DeadKeyInfo(deadKeyChar: "ˆ"), // 'i'
+        0x2d: DeadKeyInfo(deadKeyChar: "˜")  // 'n'
+    ]
+
+    // Attempts to combine a dead key with a character, returning the combined result
+    static func combine(deadKey: String, with char: String, shift: Bool) -> String? {
+        guard let combo = combinations.first(where: { $0.deadKey == deadKey && $0.combiningChar == char.lowercased() }) else {
+            return nil
+        }
+        return shift ? combo.uppercasedResult : combo.lowercasedResult
+    }
+}

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -412,6 +412,8 @@ final class SegmentsManager {
             } else {
                 return .hidden
             }
+        case .deadKeyComposition(let deadKeyChar):
+            return .hidden
         }
     }
 
@@ -498,10 +500,13 @@ final class SegmentsManager {
         suggestSelectionIndex = nil
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     func getCurrentMarkedText(inputState: InputState) -> MarkedText {
         switch inputState {
         case .none:
             return MarkedText(text: [], selectionRange: .notFound)
+        case .deadKeyComposition(let deadKeyChar):
+            return MarkedText(text: [.init(content: self.composingText.convertTarget, focus: .focused)], selectionRange: .notFound)
         case .composing:
             let text = if self.lastOperation == .delete {
                 // 削除のあとは常にひらがなを示す
@@ -537,7 +542,6 @@ final class SegmentsManager {
             } else {
                 return MarkedText(text: [.init(content: self.composingText.convertTarget, focus: .none)], selectionRange: .notFound)
             }
-
         case .replaceSuggestion:
             // サジェスト候補の選択状態を独立して管理
             if let index = suggestSelectionIndex,

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -19,6 +19,22 @@ extension UserAction {
                 KeyMap.h2zMap
             }
         }
+        // Diacritic processing
+        if event.modifierFlags.contains(.option) && event.modifierFlags.isDisjoint(with: [.command, .control]) {
+            if let deadKeyInfo = DeadKeyComposer.deadKeyList[event.keyCode] {
+                if event.modifierFlags.contains(.shift) {
+                    // Shift + Option: insert diacritical mark only
+                    if let directChar = event.characters {
+                        return .input(directChar)
+                    } else {
+                        return .unknown
+                    }
+                } else {
+                    // Option only: begin dead key sequence
+                    return .deadKey(deadKeyInfo.deadKeyChar)
+                }
+            }
+        }
         switch event.keyCode {
         case 0x04: // 'H'
             // Ctrl + H is binding for backspace

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -295,6 +295,23 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         case .transformSelectedText(let selectedText, let prompt):
             self.segmentsManager.appendDebugMessage("Executing transformSelectedText with text: '\(selectedText)' and prompt: '\(prompt)'")
             self.transformSelectedText(selectedText: selectedText, prompt: prompt)
+        // DeadKey handling
+        case .setMarkedTextAndTransition(let string, let inputState):
+            self.segmentsManager.stopComposition()
+            self.segmentsManager.insertAtCursorPosition(string, inputStyle: .direct)
+            self.inputState = inputState
+        case .commitMarkedTextAndReplaceWith(let string):
+            client.insertText(string, replacementRange: NSRange(location: NSNotFound, length: 0))
+            self.segmentsManager.stopComposition()
+        case .commitMarkedTextAndThenInsert(let stringToInsert):
+            let committedText = self.segmentsManager.commitMarkedText(inputState: self.inputState)
+            let textToInsert = committedText + stringToInsert
+            client.insertText(textToInsert, replacementRange: NSRange(location: NSNotFound, length: 0))
+            self.inputState = .none
+        case .stopCompositionAndSelectInputLanguage(let language):
+            self.segmentsManager.stopComposition()
+            self.inputLanguage = language
+            self.switchInputLanguage(language, client: client)
         // MARK: 特殊ケース
         case .consume:
             // 何もせず先に進む


### PR DESCRIPTION
`azooKey (English)`にデッドキー機能を追加します。これにより、特定の発音区別符号(Diacritic)付き文字をキーボードで入力できるようになります。

## 追加するデッドキー
以下のデッドキーを追加します。デッドキーに続いて対応する文字を入力することで発音区別符号付き文字を生成します。
-   **分音符/ウムラウト**（例: ü, ö, ä, ï）: `Option` + `U`
-   **アキュートアクセント**（例: é, á, í, ó, ú）: `Option` + `E`
-   **グレーブアクセント**（例: è, à, ì, ò, ù）: `Option` + `` ` `` (US配列) ／ option + `_` (JIS配列)
-   **サーカムフレックス**（例: ê, â, î, ô, û）: `Option` + `I`
-   **ティルダ**（例: ñ, õ）: `Option` + `N`
<img width="380" src="https://github.com/user-attachments/assets/3197660d-9dac-452d-9d78-13d3ec08ee7c"/>
<img width="380" src="https://github.com/user-attachments/assets/01924ab5-ea13-4da2-a026-414ad01fde1f"/>

## 主な変更点
1. **`DeadKeyComposer`構造体の追加**
デッドキーの組み合わせと合成処理を管理する`DeadKeyComposer`構造体を追加します。
2. **追加する`InputState`**
デッドキー合成中の状態`deadKeyComposition(String)`を追加します。
3. **追加する`UserAction`**
`deadKey(String)`アクションを追加します。
4. **追加する`ClientAction`**
デッドキー処理をサポートする以下のアクションを追加します。
   -   `setMarkedTextAndTransition(String, InputState)`
   -   `commitMarkedTextAndReplaceWith(String)`
   -   `commitMarkedTextAndThenInsert(String)`
   -   `stopCompositionAndSelectInputLanguage(InputLanguage)`