### PR TITLE
feat: add tab key support for candidate selection

### DIFF
--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -281,7 +281,14 @@ public enum InputState: Sendable, Hashable {
                 return (.consume, .fallthrough)
             case .英数:
                 return (.commitMarkedTextAndSelectInputLanguage(.english), .transition(.none))
-            case .unknown, .suggest, .tab, .transformSelectedText, .deadKey:
+            case .tab:
+                // シフトが入っている場合は前の候補に移動、そうでなければ次の候補に移動
+                if event.modifierFlags.contains(.shift) {
+                    return (.selectPrevCandidate, .fallthrough)
+                } else {
+                    return (.selectNextCandidate, .fallthrough)
+                }
+            case .unknown, .suggest, .transformSelectedText, .deadKey:
                 return (.fallthrough, .fallthrough)
             }
         case .replaceSuggestion:


### PR DESCRIPTION
他の日本語IMEと同様にTab / Shift + Tab キーで変換候補を選択できるように対応

## Tab: 次の候補を選択

![CleanShot 2025-06-26 at 18 53 33@2x](https://github.com/user-attachments/assets/d5ddca7d-aba9-4daa-b0ff-af155139794c)

## Shift+Tab: 前の候補を選択

![CleanShot 2025-06-26 at 18 55 07@2x](https://github.com/user-attachments/assets/1839bc73-170d-4505-b04a-af8f2b4b073b)
