### PR TITLE
[DNM] feat: minimum implementation of XPC service

### DIFF
--- a/ConverterServer/ConverterServer.entitlements
+++ b/ConverterServer/ConverterServer.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+</dict>
+</plist>

--- a/ConverterServer/ConverterXPC.swift
+++ b/ConverterServer/ConverterXPC.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// This object implements the protocol which we have defined. It provides the actual behavior for the service. It is 'exported' by the service to make it available to the process hosting the service over an NSXPCConnection.
+class ConverterXPC: NSObject, ConverterXPCProtocol {
+
+    /// This implements the example protocol. Replace the body of this class with the implementation of this service's protocol.
+    @objc func performCalculation(firstNumber: Int, secondNumber: Int, with reply: @escaping (Int) -> Void) {
+        let response = firstNumber + secondNumber
+        reply(response)
+    }
+}

--- a/ConverterServer/main.swift
+++ b/ConverterServer/main.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+let listener = NSXPCListener(machServiceName: "dev.ensan.inputmethod.azooKeyMac.ConverterServer")
+class ServiceDelegate: NSObject, NSXPCListenerDelegate {
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        conn.exportedInterface = NSXPCInterface(with: ConverterXPCProtocol.self)
+        conn.exportedObject    = ConverterXPC()          // 既存ロジック
+        conn.resume()
+        return true
+    }
+}
+let delegate = ServiceDelegate()
+listener.delegate = delegate
+listener.resume()
+RunLoop.current.run()          // プロセスを常駐させる

--- a/ConverterXPC/ConverterXPC.entitlements
+++ b/ConverterXPC/ConverterXPC.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/ConverterXPC/ConverterXPC.swift
+++ b/ConverterXPC/ConverterXPC.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// This object implements the protocol which we have defined. It provides the actual behavior for the service. It is 'exported' by the service to make it available to the process hosting the service over an NSXPCConnection.
+class ConverterXPC: NSObject, ConverterXPCProtocol {
+
+    /// This implements the example protocol. Replace the body of this class with the implementation of this service's protocol.
+    @objc func performCalculation(firstNumber: Int, secondNumber: Int, with reply: @escaping (Int) -> Void) {
+        let response = firstNumber + secondNumber
+        reply(response)
+    }
+}

--- a/ConverterXPC/ConverterXPCProtocol.swift
+++ b/ConverterXPC/ConverterXPCProtocol.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The protocol that this service will vend as its API. This protocol will also need to be visible to the process hosting the service.
+@objc protocol ConverterXPCProtocol {
+
+    /// Replace the API of this protocol with an API appropriate to the service you are vending.
+    func performCalculation(firstNumber: Int, secondNumber: Int, with reply: @escaping (Int) -> Void)
+}
+
+/*
+ To use the service from an application or other process, use NSXPCConnection to establish a connection to the service by doing something like this:
+
+     connectionToService = NSXPCConnection(serviceName: "dev.ensan.inputmethod.azooKeyMac.ConverterXPC")
+     connectionToService.remoteObjectInterface = NSXPCInterface(with: (any ConverterXPCProtocol).self)
+     connectionToService.resume()
+
+ Once you have a connection to the service, you can use it like this:
+
+     if let proxy = connectionToService.remoteObjectProxy as? ConverterXPCProtocol {
+         proxy.performCalculation(firstNumber: 23, secondNumber: 19) { result in
+             NSLog("Result of calculation is: \(result)")
+         }
+     }
+
+ And, when you are finished with the service, clean up the connection like this:
+
+     connectionToService.invalidate()
+*/

--- a/ConverterXPC/Info.plist
+++ b/ConverterXPC/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/ConverterXPC/main.swift
+++ b/ConverterXPC/main.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+class ServiceDelegate: NSObject, NSXPCListenerDelegate {
+
+    /// This method is where the NSXPCListener configures, accepts, and resumes a new incoming NSXPCConnection.
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+
+        // Configure the connection.
+        // First, set the interface that the exported object implements.
+        newConnection.exportedInterface = NSXPCInterface(with: (any ConverterXPCProtocol).self)
+
+        // Next, set the object that the connection exports. All messages sent on the connection to this service will be sent to the exported object to handle. The connection retains the exported object.
+        let exportedObject = ConverterXPC()
+        newConnection.exportedObject = exportedObject
+
+        // Resuming the connection allows the system to deliver more incoming messages.
+        newConnection.resume()
+
+        // Returning true from this method tells the system that you have accepted this connection. If you want to reject the connection for some reason, call invalidate() on the connection and return false.
+        return true
+    }
+}
+
+// Create the delegate for the service.
+let delegate = ServiceDelegate()
+
+// Set up the one NSXPCListener for this service. It will handle all incoming connections.
+let listener = NSXPCListener.service()
+listener.delegate = delegate
+
+// Resuming the serviceListener starts this service. This method does not return.
+listener.resume()

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		551434E82D576B6600A9B5CA /* lm_c_abc.marisa in Resources */ = {isa = PBXBuildFile; fileRef = 551434E12D576B6600A9B5CA /* lm_c_abc.marisa */; };
 		551434EA2D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 551434E92D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf */; };
 		553F47C92E0FD55100BCE1AE /* ConverterXPC.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		553F47E12E0FDA0000BCE1AE /* ConverterServer in CopyFiles */ = {isa = PBXBuildFile; fileRef = 553F47D52E0FD91F00BCE1AE /* ConverterServer */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		554A26602DB37657003C5CFB /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 554A265F2DB37657003C5CFB /* Core */; };
 		556C52FB2BAAAF7E00EB343F /* en.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52F92BAAAF7D00EB343F /* en.tiff */; };
 		556C52FC2BAAAF7E00EB343F /* en@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52FA2BAAAF7D00EB343F /* en@2x.tiff */; };
@@ -59,6 +60,25 @@
 			name = "Embed XPC Services";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		553F47D32E0FD91F00BCE1AE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		553F47E02E0FD9F400BCE1AE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				553F47E12E0FDA0000BCE1AE /* ConverterServer in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +96,7 @@
 		551434E42D576B6600A9B5CA /* lm_u_xbc.marisa */ = {isa = PBXFileReference; lastKnownFileType = file; name = lm_u_xbc.marisa; path = base_n5_lm/lm_u_xbc.marisa; sourceTree = "<group>"; };
 		551434E92D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "ggml-model-Q5_K_M.gguf"; path = "zenz-v3-small-gguf/ggml-model-Q5_K_M.gguf"; sourceTree = "<group>"; };
 		553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = ConverterXPC.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		553F47D52E0FD91F00BCE1AE /* ConverterServer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ConverterServer; sourceTree = BUILT_PRODUCTS_DIR; };
 		556C52F92BAAAF7D00EB343F /* en.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = en.tiff; sourceTree = "<group>"; };
 		556C52FA2BAAAF7D00EB343F /* en@2x.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "en@2x.tiff"; sourceTree = "<group>"; };
 		55A27D012BAAADDB00512DCD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -98,10 +119,18 @@
 			);
 			target = 1A41E61326E745D9009B65D7 /* azooKeyMac */;
 		};
+		553F47DD2E0FD93400BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ConverterXPCProtocol.swift,
+			);
+			target = 553F47D42E0FD91F00BCE1AE /* ConverterServer */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		553F47BE2E0FD55100BCE1AE /* ConverterXPC */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (553F47D02E0FD6CC00BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 553F47CD2E0FD55100BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ConverterXPC; sourceTree = "<group>"; };
+		553F47BE2E0FD55100BCE1AE /* ConverterXPC */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (553F47D02E0FD6CC00BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 553F47CD2E0FD55100BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 553F47DD2E0FD93400BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ConverterXPC; sourceTree = "<group>"; };
+		553F47D62E0FD91F00BCE1AE /* ConverterServer */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ConverterServer; sourceTree = "<group>"; };
 		55CE06C72CB01F000002DAF1 /* InputController */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InputController; sourceTree = "<group>"; };
 		55CE06D72CB01F080002DAF1 /* Configs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configs; sourceTree = "<group>"; };
 		55CE06E42CB01F130002DAF1 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
@@ -141,6 +170,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		553F47D22E0FD91F00BCE1AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -152,6 +188,7 @@
 				55CE06ED2CB01F160002DAF1 /* azooKeyMacTests */,
 				55CE06F12CB01F160002DAF1 /* azooKeyMacUITests */,
 				553F47BE2E0FD55100BCE1AE /* ConverterXPC */,
+				553F47D62E0FD91F00BCE1AE /* ConverterServer */,
 				1A41E61526E745D9009B65D7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -163,6 +200,7 @@
 				1A41E62426E745DD009B65D7 /* azooKeyMacTests.xctest */,
 				1A41E62E26E745DD009B65D7 /* azooKeyMacUITests.xctest */,
 				553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */,
+				553F47D52E0FD91F00BCE1AE /* ConverterServer */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -212,6 +250,7 @@
 				1A41E61126E745D9009B65D7 /* Frameworks */,
 				1A41E61226E745D9009B65D7 /* Resources */,
 				553F47CA2E0FD55100BCE1AE /* Embed XPC Services */,
+				553F47E02E0FD9F400BCE1AE /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -298,6 +337,28 @@
 			productReference = 553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */;
 			productType = "com.apple.product-type.xpc-service";
 		};
+		553F47D42E0FD91F00BCE1AE /* ConverterServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 553F47D92E0FD91F00BCE1AE /* Build configuration list for PBXNativeTarget "ConverterServer" */;
+			buildPhases = (
+				553F47D12E0FD91F00BCE1AE /* Sources */,
+				553F47D22E0FD91F00BCE1AE /* Frameworks */,
+				553F47D32E0FD91F00BCE1AE /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				553F47D62E0FD91F00BCE1AE /* ConverterServer */,
+			);
+			name = ConverterServer;
+			packageProductDependencies = (
+			);
+			productName = ConverterServer;
+			productReference = 553F47D52E0FD91F00BCE1AE /* ConverterServer */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -322,6 +383,9 @@
 					553F47BC2E0FD55100BCE1AE = {
 						CreatedOnToolsVersion = 16.4;
 					};
+					553F47D42E0FD91F00BCE1AE = {
+						CreatedOnToolsVersion = 16.4;
+					};
 				};
 			};
 			buildConfigurationList = 1A41E60F26E745D9009B65D7 /* Build configuration list for PBXProject "azooKeyMac" */;
@@ -344,6 +408,7 @@
 				1A41E62326E745DD009B65D7 /* azooKeyMacTests */,
 				1A41E62D26E745DD009B65D7 /* azooKeyMacUITests */,
 				553F47BC2E0FD55100BCE1AE /* ConverterXPC */,
+				553F47D42E0FD91F00BCE1AE /* ConverterServer */,
 			);
 		};
 /* End PBXProject section */
@@ -414,6 +479,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		553F47B92E0FD55100BCE1AE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		553F47D12E0FD91F00BCE1AE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -795,6 +867,41 @@
 			};
 			name = Release;
 		};
+		553F47DA2E0FD91F00BCE1AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = ConverterServer/ConverterServer.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9S3UXHYP65;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		553F47DB2E0FD91F00BCE1AE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = ConverterServer/ConverterServer.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9S3UXHYP65;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -839,6 +946,15 @@
 			buildConfigurations = (
 				553F47CB2E0FD55100BCE1AE /* Debug */,
 				553F47CC2E0FD55100BCE1AE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		553F47D92E0FD91F00BCE1AE /* Build configuration list for PBXNativeTarget "ConverterServer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				553F47DA2E0FD91F00BCE1AE /* Debug */,
+				553F47DB2E0FD91F00BCE1AE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/azooKeyMac.xcodeproj/project.pbxproj
+++ b/azooKeyMac.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		551434E72D576B6600A9B5CA /* lm_r_xbx.marisa in Resources */ = {isa = PBXBuildFile; fileRef = 551434E22D576B6600A9B5CA /* lm_r_xbx.marisa */; };
 		551434E82D576B6600A9B5CA /* lm_c_abc.marisa in Resources */ = {isa = PBXBuildFile; fileRef = 551434E12D576B6600A9B5CA /* lm_c_abc.marisa */; };
 		551434EA2D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 551434E92D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf */; };
+		553F47C92E0FD55100BCE1AE /* ConverterXPC.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		554A26602DB37657003C5CFB /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 554A265F2DB37657003C5CFB /* Core */; };
 		556C52FB2BAAAF7E00EB343F /* en.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52F92BAAAF7D00EB343F /* en.tiff */; };
 		556C52FC2BAAAF7E00EB343F /* en@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 556C52FA2BAAAF7D00EB343F /* en@2x.tiff */; };
@@ -37,7 +38,28 @@
 			remoteGlobalIDString = 1A41E61326E745D9009B65D7;
 			remoteInfo = azooKeyMac;
 		};
+		553F47C72E0FD55100BCE1AE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A41E60C26E745D9009B65D7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 553F47BC2E0FD55100BCE1AE;
+			remoteInfo = ConverterXPC;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		553F47CA2E0FD55100BCE1AE /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				553F47C92E0FD55100BCE1AE /* ConverterXPC.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1A41E61426E745D9009B65D7 /* azooKeyMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = azooKeyMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -53,6 +75,7 @@
 		551434E32D576B6600A9B5CA /* lm_u_abx.marisa */ = {isa = PBXFileReference; lastKnownFileType = file; name = lm_u_abx.marisa; path = base_n5_lm/lm_u_abx.marisa; sourceTree = "<group>"; };
 		551434E42D576B6600A9B5CA /* lm_u_xbc.marisa */ = {isa = PBXFileReference; lastKnownFileType = file; name = lm_u_xbc.marisa; path = base_n5_lm/lm_u_xbc.marisa; sourceTree = "<group>"; };
 		551434E92D57A8AC00A9B5CA /* ggml-model-Q5_K_M.gguf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "ggml-model-Q5_K_M.gguf"; path = "zenz-v3-small-gguf/ggml-model-Q5_K_M.gguf"; sourceTree = "<group>"; };
+		553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = ConverterXPC.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		556C52F92BAAAF7D00EB343F /* en.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = en.tiff; sourceTree = "<group>"; };
 		556C52FA2BAAAF7D00EB343F /* en@2x.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "en@2x.tiff"; sourceTree = "<group>"; };
 		55A27D012BAAADDB00512DCD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -60,7 +83,25 @@
 		55D3B7632DB36BDE00044FD1 /* Core */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Core; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		553F47CD2E0FD55100BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 553F47BC2E0FD55100BCE1AE /* ConverterXPC */;
+		};
+		553F47D02E0FD6CC00BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ConverterXPCProtocol.swift,
+			);
+			target = 1A41E61326E745D9009B65D7 /* azooKeyMac */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		553F47BE2E0FD55100BCE1AE /* ConverterXPC */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (553F47D02E0FD6CC00BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 553F47CD2E0FD55100BCE1AE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ConverterXPC; sourceTree = "<group>"; };
 		55CE06C72CB01F000002DAF1 /* InputController */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InputController; sourceTree = "<group>"; };
 		55CE06D72CB01F080002DAF1 /* Configs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configs; sourceTree = "<group>"; };
 		55CE06E42CB01F130002DAF1 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
@@ -93,6 +134,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		553F47BA2E0FD55100BCE1AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -103,6 +151,7 @@
 				1A41E61626E745D9009B65D7 /* azooKeyMac */,
 				55CE06ED2CB01F160002DAF1 /* azooKeyMacTests */,
 				55CE06F12CB01F160002DAF1 /* azooKeyMacUITests */,
+				553F47BE2E0FD55100BCE1AE /* ConverterXPC */,
 				1A41E61526E745D9009B65D7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,6 +162,7 @@
 				1A41E61426E745D9009B65D7 /* azooKeyMac.app */,
 				1A41E62426E745DD009B65D7 /* azooKeyMacTests.xctest */,
 				1A41E62E26E745DD009B65D7 /* azooKeyMacUITests.xctest */,
+				553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -161,11 +211,13 @@
 				1A41E61026E745D9009B65D7 /* Sources */,
 				1A41E61126E745D9009B65D7 /* Frameworks */,
 				1A41E61226E745D9009B65D7 /* Resources */,
+				553F47CA2E0FD55100BCE1AE /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				554A26622DB3765F003C5CFB /* PBXTargetDependency */,
+				553F47C82E0FD55100BCE1AE /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				55CE06C72CB01F000002DAF1 /* InputController */,
@@ -224,6 +276,28 @@
 			productReference = 1A41E62E26E745DD009B65D7 /* azooKeyMacUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		553F47BC2E0FD55100BCE1AE /* ConverterXPC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 553F47CE2E0FD55100BCE1AE /* Build configuration list for PBXNativeTarget "ConverterXPC" */;
+			buildPhases = (
+				553F47B92E0FD55100BCE1AE /* Sources */,
+				553F47BA2E0FD55100BCE1AE /* Frameworks */,
+				553F47BB2E0FD55100BCE1AE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				553F47BE2E0FD55100BCE1AE /* ConverterXPC */,
+			);
+			name = ConverterXPC;
+			packageProductDependencies = (
+			);
+			productName = ConverterXPC;
+			productReference = 553F47BD2E0FD55100BCE1AE /* ConverterXPC.xpc */;
+			productType = "com.apple.product-type.xpc-service";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -231,7 +305,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1300;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1530;
 				TargetAttributes = {
 					1A41E61326E745D9009B65D7 = {
@@ -244,6 +318,9 @@
 					1A41E62D26E745DD009B65D7 = {
 						CreatedOnToolsVersion = 13.0;
 						TestTargetID = 1A41E61326E745D9009B65D7;
+					};
+					553F47BC2E0FD55100BCE1AE = {
+						CreatedOnToolsVersion = 16.4;
 					};
 				};
 			};
@@ -266,6 +343,7 @@
 				1A41E61326E745D9009B65D7 /* azooKeyMac */,
 				1A41E62326E745DD009B65D7 /* azooKeyMacTests */,
 				1A41E62D26E745DD009B65D7 /* azooKeyMacUITests */,
+				553F47BC2E0FD55100BCE1AE /* ConverterXPC */,
 			);
 		};
 /* End PBXProject section */
@@ -303,6 +381,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		553F47BB2E0FD55100BCE1AE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -328,6 +413,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		553F47B92E0FD55100BCE1AE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -340,6 +432,11 @@
 			isa = PBXTargetDependency;
 			target = 1A41E61326E745D9009B65D7 /* azooKeyMac */;
 			targetProxy = 1A41E62F26E745DD009B65D7 /* PBXContainerItemProxy */;
+		};
+		553F47C82E0FD55100BCE1AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 553F47BC2E0FD55100BCE1AE /* ConverterXPC */;
+			targetProxy = 553F47C72E0FD55100BCE1AE /* PBXContainerItemProxy */;
 		};
 		554A26622DB3765F003C5CFB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -641,6 +738,63 @@
 			};
 			name = Release;
 		};
+		553F47CB2E0FD55100BCE1AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = ConverterXPC/ConverterXPC.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9S3UXHYP65;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ConverterXPC/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ConverterXPC;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ensan.inputmethod.azooKeyMac.ConverterXPC;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		553F47CC2E0FD55100BCE1AE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = ConverterXPC/ConverterXPC.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9S3UXHYP65;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ConverterXPC/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ConverterXPC;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ensan.inputmethod.azooKeyMac.ConverterXPC;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -676,6 +830,15 @@
 			buildConfigurations = (
 				1A41E63F26E745DD009B65D7 /* Debug */,
 				1A41E64026E745DD009B65D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		553F47CE2E0FD55100BCE1AE /* Build configuration list for PBXNativeTarget "ConverterXPC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				553F47CB2E0FD55100BCE1AE /* Debug */,
+				553F47CC2E0FD55100BCE1AE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputControllerHelper.swift
@@ -10,6 +10,8 @@ extension azooKeyMacInputController {
         self.appMenu.addItem(self.zenzaiToggleMenuItem)
         self.appMenu.addItem(self.liveConversionToggleMenuItem)
         self.appMenu.addItem(NSMenuItem.separator())
+        let callXPCMenuItem = NSMenuItem(title: "Converter Processと通信", action: #selector(self.callConverterProcess(_:)), keyEquivalent: "")
+        self.appMenu.addItem(callXPCMenuItem)
         self.appMenu.addItem(NSMenuItem(title: "詳細設定を開く", action: #selector(self.openConfigWindow(_:)), keyEquivalent: ""))
         self.appMenu.addItem(NSMenuItem(title: "View on GitHub", action: #selector(self.openGitHubRepository(_:)), keyEquivalent: ""))
     }
@@ -56,6 +58,16 @@ extension azooKeyMacInputController {
             try FileManager.default.createDirectory(at: self.segmentsManager.azooKeyMemoryDir, withIntermediateDirectories: true)
         } catch {
             self.segmentsManager.appendDebugMessage("\(#line): \(error.localizedDescription)")
+        }
+    }
+
+    @objc func callConverterProcess(_ sender: Any) {
+        self.callXPCExample(firstNumber: 42, secondNumber: 58) { result in
+            if let result = result {
+                self.segmentsManager.appendDebugMessage("XPC result: \(result)")
+            } else {
+                self.segmentsManager.appendDebugMessage("XPC call failed")
+            }
         }
     }
 }

--- a/azooKeyMac/azooKeyMac.entitlements
+++ b/azooKeyMac/azooKeyMac.entitlements
@@ -12,5 +12,9 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-register.global-name</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)_Connection</string>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>dev.ensan.inputmethod.azooKeyMac.ConverterServer</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
このPRでは、プロセス分離に向けたサンプルを実装した。メニューバー上で「プロセスと通信」を押すと、`ConverterServer`という起動している別プロセスにCross-Process Connectionが飛び、簡単なデータの送受信が実行され、結果がデバッグログに表示される。

* `ConverterServer`: Launch Agentとして変換を担うプロセスを想定。
* `ConverterXPC`: On-Demandで起動され、1つの処理を終えると終了するプロセス。今回の実装で試したが、不要であった。

`~/Library/LaunchAgents`に`dev.ensan.inputmethod.azooKeyMac.ConverterServer.plist`を配置して使える。
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
 "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Label</key>
    <string>dev.ensan.inputmethod.azooKeyMac.ConverterServer</string>

    <key>ProgramArguments</key>
    <array>
        <string>/Library/Input Methods/azooKeyMac.app/Contents/MacOS/ConverterServer</string>
    </array>

    <key>MachServices</key>
    <dict>
        <key>dev.ensan.inputmethod.azooKeyMac.ConverterServer</key>
        <true/>
    </dict>

    <key>RunAtLoad</key><true/>
    <key>KeepAlive</key><true/>
</dict>
</plist>
```