### PR TITLE
feat: Control+M で変換を確定できるように

### DIFF
--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -53,6 +53,14 @@ extension UserAction {
             } else {
                 return .unknown
             }
+        case 0x2E: // Control + m
+            if event.modifierFlags.contains(.control) {
+                return .enter
+            } else if let text = event.characters, isPrintable(text) {
+                return .input(keyMap(text))
+            } else {
+                return .unknown
+            }
         case 0x2D: // Control + n
             if event.modifierFlags.contains(.control) {
                 return .navigation(.down)


### PR DESCRIPTION
## 概要

Control+M キーで変換を確定できるようにしました。

## 背景

すでに Control+P/N などの emacs/vim 風のキーバインディングがサポートされているため、合わせて Control+M もサポートするようにしました。
mac標準やGoogle日本語入力などでも Ctrl+M は変換の確定に割り当てられているため、一般的なキーバインディングに合わせる目的もあります。

## 動作確認

以下の状態で Control+M を押した際に、Enter キーと同じ動作をすることを確認しました。

- 文字入力中（composing状態）
- 変換候補プレビュー中（previewing状態）
- 候補選択中（selecting状態）

## テスト

- [x] SwiftLint: エラーなし
- [x] ビルド: 成功
- [x] 手動テスト: 各種入力状態で動作確認済み
