### PR TITLE
feat: AzooKeyKanaKanjiConverterをv0.9.0に更新し、破壊的変更に対処

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "8b7569777c6014851a2914f5b86d287d2bace1d5", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.9.0", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "328af40c7e37b98a7f2adeb475b40c5a46a6d5e8", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "8b7569777c6014851a2914f5b86d287d2bace1d5", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/azooKeyMac/Configs/StringConfigItem.swift
+++ b/azooKeyMac/Configs/StringConfigItem.swift
@@ -71,7 +71,7 @@ extension Config {
     struct OpenAiApiEndpoint: StringConfigItem {
         static let `default` = "https://api.openai.com/v1/chat/completions"
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.OpenAiApiEndpoint"
-        
+
         var value: String {
             get {
                 UserDefaults.standard.string(forKey: Self.key) ?? Self.default

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -545,7 +545,7 @@ extension azooKeyMacInputController {
                     Candidate(
                         text: text,
                         value: PValue(0),
-                        correspondingCount: text.count,
+                        composingCount: .surfaceCount(composingText.count),
                         lastMid: 0,
                         data: [],
                         actions: [],


### PR DESCRIPTION
このPRではAzooKeyKanaKanjiConverterのバージョンをv0.9系（beta）に更新する。機能的な変更としては以下のような変更が取り込まれる。特に https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/223 により、長く問題となっていた`ComposingText`の`input`が破壊される問題が解消され、将来的には英字変換などの導入が可能になる。

* 起動時の処理の安定化 by @mtgto in https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/217
* Lattice処理を二重インデックス化し、ComposingTextレベルで扱っていたアドホックな処理を削除 by @ensan-hcl https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/223

なお、このほかにv0.9.0ではいくつかのAPIの破壊的変更が生じるため、本PRではこれにも対処している。具体的には`Candidate.correspondingCount`が型違いの`Candidate.composingCount`に変更になった。