### PR TITLE
Fix roman candidate creation

### DIFF
--- a/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/ClientAction.swift
@@ -47,6 +47,8 @@ public enum ClientAction {
     case submitKatakanaCandidate
     case submitHiraganaCandidate
     case submitHankakuKatakanaCandidate
+    case submitFullWidthRomanCandidate
+    case submitHalfWidthRomanCandidate
 
     // PredictiveSuggestion
     case requestPredictiveSuggestion

--- a/Core/Sources/Core/InputUtils/Actions/UserAction.swift
+++ b/Core/Sources/Core/InputUtils/Actions/UserAction.swift
@@ -22,7 +22,7 @@ public enum UserAction {
     }
 
     public enum Function: Sendable, Equatable, Hashable {
-        case six, seven, eight
+        case six, seven, eight, nine, ten
     }
 
     public enum Number: Sendable, Equatable, Hashable {

--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -145,6 +145,10 @@ public enum InputState: Sendable, Hashable {
                     return (.submitKatakanaCandidate, .transition(.none))
                 case .eight:
                     return (.submitHankakuKatakanaCandidate, .transition(.none))
+                case .nine:
+                    return (.submitFullWidthRomanCandidate, .transition(.none))
+                case .ten:
+                    return (.submitHalfWidthRomanCandidate, .transition(.none))
                 }
             case .かな:
                 return (.consume, .fallthrough)
@@ -194,6 +198,10 @@ public enum InputState: Sendable, Hashable {
                     return (.submitKatakanaCandidate, .transition(.none))
                 case .eight:
                     return (.submitHankakuKatakanaCandidate, .transition(.none))
+                case .nine:
+                    return (.submitFullWidthRomanCandidate, .transition(.none))
+                case .ten:
+                    return (.submitHalfWidthRomanCandidate, .transition(.none))
                 }
             case .かな:
                 return (.consume, .fallthrough)
@@ -265,6 +273,10 @@ public enum InputState: Sendable, Hashable {
                     return (.submitKatakanaCandidate, .basedOnSubmitCandidate(ifIsEmpty: .none, ifIsNotEmpty: .selecting))
                 case .eight:
                     return (.submitHankakuKatakanaCandidate, .basedOnSubmitCandidate(ifIsEmpty: .none, ifIsNotEmpty: .selecting))
+                case .nine:
+                    return (.submitFullWidthRomanCandidate, .basedOnSubmitCandidate(ifIsEmpty: .none, ifIsNotEmpty: .selecting))
+                case .ten:
+                    return (.submitHalfWidthRomanCandidate, .basedOnSubmitCandidate(ifIsEmpty: .none, ifIsNotEmpty: .selecting))
                 }
             case .number(let num):
                 switch num {

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -479,6 +479,26 @@ final class SegmentsManager {
     }
 
     @MainActor
+    func getModifiedRomanCandidate(_ transform: (String) -> String) -> Candidate {
+        let inputString = self.composingText.input.map(\.character).joined()
+        let candidateText = transform(inputString)
+        let candidate = Candidate(
+            text: candidateText,
+            value: 0,
+            composingCount: .inputCount(composingText.input.count),
+            lastMid: 0,
+            data: [DicdataElement(
+                word: candidateText,
+                ruby: inputString,
+                cid: CIDData.固有名詞.cid,
+                mid: MIDData.一般.mid,
+                value: 0
+            )]
+        )
+        return candidate
+    }
+
+    @MainActor
     func commitMarkedText(inputState: InputState) -> String {
         let markedText = self.getCurrentMarkedText(inputState: inputState)
         let text = markedText.reduce(into: "") {$0.append(contentsOf: $1.content)}

--- a/azooKeyMac/InputController/UserAction+getUserAction.swift
+++ b/azooKeyMac/InputController/UserAction+getUserAction.swift
@@ -180,6 +180,10 @@ extension UserAction {
             return .function(.seven)
         case 100: // F8
             return .function(.eight)
+        case 101: // F9
+            return .function(.nine)
+        case 109: // F10
+            return .function(.ten)
         case 102: // Lang2/kVK_JIS_Eisu
             return .英数
         case 104: // Lang1/kVK_JIS_Kana

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -255,6 +255,14 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
             self.submitCandidate(self.segmentsManager.getModifiedRubyCandidate {
                 $0.toKatakana().applyingTransform(.fullwidthToHalfwidth, reverse: false)!
             })
+        case .submitFullWidthRomanCandidate:
+            self.submitCandidate(self.segmentsManager.getModifiedRomanCandidate {
+                $0.applyingTransform(.halfwidthToFullwidth, reverse: false)!
+            })
+        case .submitHalfWidthRomanCandidate:
+            self.submitCandidate(self.segmentsManager.getModifiedRomanCandidate {
+                $0.applyingTransform(.fullwidthToHalfwidth, reverse: false)!
+            })
         case .enableDebugWindow:
             self.segmentsManager.requestDebugWindowMode(enabled: true)
         case .disableDebugWindow:


### PR DESCRIPTION
## Summary
- add `getModifiedRomanCandidate` that builds a Candidate from composingText input
- use the new helper for F9 (full-width Roman) and F10 (half-width Roman) actions

## Testing
- `apt-get update`
- `apt-get install -y swiftlang` *(failed: package not found)*
- `swift build --package-path Core` *(failed: command not found)*
- `swift test --package-path Core` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6d6db2d4833093192c8ece2a70e0