### PR TITLE
feat: AzooKeyKanaKanjiConverterを更新し、AZIKに対応し、末尾の`n`を`ん`に変更する機能をサポート

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "95e5d9368d64edc4a6201535a68ca54755ec376e", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "b3ddfb236a998c85ce407744b49dec8f31d94ad5", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "d8b06e93670cd8f0869597a3c658e1cd973ad583", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "95e5d9368d64edc4a6201535a68ca54755ec376e", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.9.0", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "d8b06e93670cd8f0869597a3c658e1cd973ad583", traits: ["Zenzai"]),
     ],
     targets: [
         .executableTarget(

--- a/azooKeyMac/Configs/CustomCodableConfigItem.swift
+++ b/azooKeyMac/Configs/CustomCodableConfigItem.swift
@@ -131,3 +131,14 @@ extension Config {
         static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.zenzai.personalization_level"
     }
 }
+
+extension Config {
+    struct InputStyle: CustomCodableConfigItem {
+        enum Value: String, Codable, Equatable, Hashable {
+            case `default`
+            case defaultAZIK
+        }
+        static var `default`: Value = .default
+        static var key: String = "dev.ensan.inputmethod.azooKeyMac.preference.input_style"
+    }
+}

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -198,6 +198,15 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         return handleClientAction(clientAction, clientActionCallback: clientActionCallback, client: client)
     }
 
+    private var inputStyle: InputStyle {
+        switch Config.InputStyle().value {
+        case .default:
+            .roman2kana
+        case .defaultAZIK:
+            .mapped(id: .defaultAZIK)
+        }
+    }
+
     // この種のコードは複雑にしかならないので、lintを無効にする
     // swiftlint:disable:next cyclomatic_complexity
     @MainActor func handleClientAction(_ clientAction: ClientAction, clientActionCallback: ClientActionCallback, client: IMKTextInput) -> Bool {
@@ -212,7 +221,7 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         case .enterCandidateSelectionMode:
             self.segmentsManager.update(requestRichCandidates: true)
         case .appendToMarkedText(let string):
-            self.segmentsManager.insertAtCursorPosition(string, inputStyle: .roman2kana)
+            self.segmentsManager.insertAtCursorPosition(string, inputStyle: self.inputStyle)
         case .insertWithoutMarkedText(let string):
             client.insertText(string, replacementRange: NSRange(location: NSNotFound, length: 0))
         case .editSegment(let count):
@@ -223,12 +232,12 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         case .commitMarkedTextAndAppendToMarkedText(let string):
             let text = self.segmentsManager.commitMarkedText(inputState: self.inputState)
             client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
-            self.segmentsManager.insertAtCursorPosition(string, inputStyle: .roman2kana)
+            self.segmentsManager.insertAtCursorPosition(string, inputStyle: self.inputStyle)
         case .submitSelectedCandidate:
             self.submitSelectedCandidate()
         case .submitSelectedCandidateAndAppendToMarkedText(let string):
             self.submitSelectedCandidate()
-            self.segmentsManager.insertAtCursorPosition(string, inputStyle: .roman2kana)
+            self.segmentsManager.insertAtCursorPosition(string, inputStyle: self.inputStyle)
         case .submitSelectedCandidateAndEnterFirstCandidatePreviewMode:
             self.submitSelectedCandidate()
             self.segmentsManager.requestSetCandidateWindowState(visible: false)
@@ -282,7 +291,7 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         // PredictiveSuggestion
         case .requestPredictiveSuggestion:
             // 「つづき」を直接入力し、コンテキストを渡す
-            self.segmentsManager.insertAtCursorPosition("つづき", inputStyle: .roman2kana)
+            self.segmentsManager.insertAtCursorPosition("つづき", inputStyle: self.inputStyle)
             self.requestReplaceSuggestion()
         // ReplaceSuggestion
         case .requestReplaceSuggestion:

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -217,8 +217,10 @@ class azooKeyMacInputController: IMKInputController { // swiftlint:disable:this 
         case .hideCandidateWindow:
             self.segmentsManager.requestSetCandidateWindowState(visible: false)
         case .enterFirstCandidatePreviewMode:
+            self.segmentsManager.insertCompositionSeparator(inputStyle: self.inputStyle, skipUpdate: false)
             self.segmentsManager.requestSetCandidateWindowState(visible: false)
         case .enterCandidateSelectionMode:
+            self.segmentsManager.insertCompositionSeparator(inputStyle: self.inputStyle, skipUpdate: true)
             self.segmentsManager.update(requestRichCandidates: true)
         case .appendToMarkedText(let string):
             self.segmentsManager.insertAtCursorPosition(string, inputStyle: self.inputStyle)

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -160,7 +160,7 @@ struct ConfigWindow: View {
                     Divider()
                     Picker("入力方式", selection: $inputStyle) {
                         Text("デフォルト").tag(Config.InputStyle.Value.default)
-                        Text("AZIK").tag(Config.InputStyle.Value.defaultAZIK)
+                        Text("AZIK（β版）").tag(Config.InputStyle.Value.defaultAZIK)
                     }
                     Divider()
                     Toggle("ライブ変換を有効化", isOn: $liveConversion)

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ConfigWindow: View {
     @ConfigState private var liveConversion = Config.LiveConversion()
+    @ConfigState private var inputStyle = Config.InputStyle()
     @ConfigState private var typeBackSlash = Config.TypeBackSlash()
     @ConfigState private var typeCommaAndPeriod = Config.TypeCommaAndPeriod()
     @ConfigState private var typeHalfSpace = Config.TypeHalfSpace()
@@ -155,6 +156,11 @@ struct ConfigWindow: View {
                             .labelsHidden()
                             .disabled(!zenzai.value)
                         helpButton(helpContent: "推論上限を小さくすると、入力中のもたつきが改善されることがあります。", isPresented: $zenzaiInferenceLimitHelpPopover)
+                    }
+                    Divider()
+                    Picker("入力方式", selection: $inputStyle) {
+                        Text("デフォルト").tag(Config.InputStyle.Value.default)
+                        Text("AZIK").tag(Config.InputStyle.Value.defaultAZIK)
                     }
                     Divider()
                     Toggle("ライブ変換を有効化", isOn: $liveConversion)


### PR DESCRIPTION
AzooKeyKanaKanjiConverterでローマ字かな入力周りに抜本的な変更を導入し、カスタムテーブルのサポートに成功した。これに伴って、以下の2つの変更を取り込んだ。

* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/227
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/228

これにより、カスタムローマ字テーブルのサポート（ #117 ）、かな入力のサポート（ #114 ）、末尾`n->ん`変換（ #178 ）などに対処することができる。このPRでは、

1. カスタムローマ字テーブル機能のサブセットとして、AZIK入力に対応
2. 末尾`n->ん`変換に対応 ( resolve #178 )

の2つが追加される。

なお、この変更は非常に大規模であり、意図しない不具合が混入する可能性があるので、怪しい挙動を見つけた場合は報告されたい。