### PR TITLE
feat: システムユーザ辞書の読み込みをサポート

### DIFF
--- a/Core/Sources/Core/UserDictionary/SystemUserDictionaryHelper.swift
+++ b/Core/Sources/Core/UserDictionary/SystemUserDictionaryHelper.swift
@@ -1,0 +1,142 @@
+import Foundation
+import SQLite3
+#if canImport(AppKit)
+import AppKit
+#endif
+
+
+/// macOSのユーザ辞書データを取り出すためのヘルパー
+///
+/// - note:
+///   `bash`コマンドとしては次の通りのものに対応
+///   ```bash
+///   sqlite3 -header -csv ~/Library/KeyboardServices/TextReplacements.db "SELECT ZSHORTCUT, ZPHRASE FROM ZTEXTREPLACEMENTENTRY"
+///   ```
+public enum SystemUserDictionaryHelper: Sendable {
+#if canImport(AppKit)
+    /// Delegate that allows the user to choose **only** a directory named "KeyboardServices".
+    private final class KeyboardServicesDirectoryDelegate: NSObject, NSOpenSavePanelDelegate {
+        private let allowedFolderName = "KeyboardServices"
+
+        /// Controls which items are enabled in the open panel.
+        func panel(_ sender: Any, shouldEnable url: URL) -> Bool {
+            // Enable selection only for the target directory itself.
+            return url.hasDirectoryPath && url.lastPathComponent == allowedFolderName
+        }
+
+        /// Validates the final URL when the user presses “Open”.
+        func panel(_ sender: Any, validate url: URL) throws {
+            guard url.lastPathComponent == allowedFolderName else {
+                throw NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: NSUserCancelledError,
+                    userInfo: [NSLocalizedDescriptionKey: "KeyboardServicesという名前のフォルダのみ選択できます。"]
+                )
+            }
+        }
+    }
+
+    /// A shared delegate instance that remains alive for the lifetime of the open panel.
+    @MainActor private static let keyboardServicesDelegate = KeyboardServicesDirectoryDelegate()
+#endif
+
+    public struct Entry: Sendable {
+        public let shortcut: String
+        public let phrase: String
+    }
+
+    public enum FetchError: Sendable, Error {
+        case fileNotExist(String)
+        case dataFeedingFailed(any Error)
+        case failedToOpenDatabase(status: Int32)
+        case failedToPrepareStatement(status: Int32)
+    }
+
+    @MainActor static func promptUserForTextReplacementDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = "システムのユーザ辞書ディレクトリ（KeyboardServices）を選択してください"
+        panel.message = "システムのユーザ辞書ディレクトリ（KeyboardServices）を選択してください"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/KeyboardServices")
+#if canImport(AppKit)
+        panel.delegate = keyboardServicesDelegate
+#endif
+
+        let response = panel.runModal()
+        return response == .OK ? panel.url : nil
+    }
+
+    @MainActor public static func fetchEntries() throws(FetchError) -> [Entry] {
+        let userName = NSUserName()
+        var dbPath = "/Users/\(userName)/Library/KeyboardServices/TextReplacements.db"
+        guard FileManager.default.fileExists(atPath: dbPath) else {
+            throw .fileNotExist(dbPath)
+        }
+        // 事前に取得を試みる
+        var originalURL = URL(fileURLWithPath: dbPath)
+        print("originalURL", originalURL)
+
+        if !FileManager.default.isReadableFile(atPath: dbPath) {
+            let directoryURL: URL
+#if canImport(AppKit)
+            if let url = Self.promptUserForTextReplacementDirectory(), url.startAccessingSecurityScopedResource() {
+                directoryURL = url
+                originalURL = directoryURL.appendingPathComponent("TextReplacements.db")
+            } else {
+                throw FetchError.fileNotExist(dbPath)
+            }
+#else
+            throw FetchError.fileNotExist(dbPath)
+#endif
+            let tempDirURL = FileManager.default.temporaryDirectory.appendingPathComponent("TextReplacementsCopy")
+            let tempDBURL = tempDirURL.appendingPathComponent("TextReplacements.db")
+            do {
+                if FileManager.default.fileExists(atPath: tempDirURL.path) {
+                    try FileManager.default.removeItem(at: tempDirURL)
+                }
+                try FileManager.default.copyItem(at: directoryURL, to: tempDirURL)
+                dbPath = tempDBURL.path
+            } catch {
+                throw FetchError.dataFeedingFailed(error)
+            }
+        }
+        var db: OpaquePointer?
+        var entries: [Entry] = []
+
+        let openStatus = sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil)
+        guard openStatus == SQLITE_OK else {
+            print("Failed to open database")
+            throw .failedToOpenDatabase(status: openStatus)
+        }
+
+        defer {
+            sqlite3_close(db)
+        }
+
+        let query = "SELECT ZSHORTCUT, ZPHRASE FROM ZTEXTREPLACEMENTENTRY"
+        var statement: OpaquePointer?
+
+        let prepareStatus = sqlite3_prepare_v2(db, query, -1, &statement, nil)
+        guard prepareStatus == SQLITE_OK else {
+            print("Failed to prepare statement")
+            throw .failedToPrepareStatement(status: prepareStatus)
+        }
+
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let shortcutC = sqlite3_column_text(statement, 0),
+               let phraseC = sqlite3_column_text(statement, 1) {
+                let shortcut = String(cString: shortcutC)
+                let phrase = String(cString: phraseC)
+                entries.append(Entry(shortcut: shortcut, phrase: phrase))
+            }
+        }
+
+        return entries
+    }
+}

--- a/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTests.swift
+++ b/Core/Tests/CoreTests/UserDictionaryTests/UserDictionaryTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import Core
+
+@Test func testSystemUserDictionaryHelper() async throws {
+    let entries = try await SystemUserDictionaryHelper.fetchEntries()
+    print(entries)
+    // always true
+    #expect(entries.count >= 0)
+}

--- a/azooKeyMac/Configs/CustomCodableConfigItem.swift
+++ b/azooKeyMac/Configs/CustomCodableConfigItem.swift
@@ -64,44 +64,56 @@ extension Config {
 }
 
 extension Config {
+    struct UserDictionaryEntry: Sendable, Codable, Identifiable {
+        init(word: String, reading: String, hint: String? = nil) {
+            self.id = UUID()
+            self.word = word
+            self.reading = reading
+            self.hint = hint
+        }
+
+        var id: UUID
+        var word: String
+        var reading: String
+        var hint: String?
+
+        var nonNullHint: String {
+            get {
+                hint ?? ""
+            }
+            set {
+                if newValue.isEmpty {
+                    hint = nil
+                } else {
+                    hint = newValue
+                }
+            }
+        }
+    }
+
     struct UserDictionary: CustomCodableConfigItem {
         var items: Value = Self.default
 
         struct Value: Codable {
-            var items: [Item]
-        }
-
-        struct Item: Codable, Identifiable {
-            init(word: String, reading: String, hint: String? = nil) {
-                self.id = UUID()
-                self.word = word
-                self.reading = reading
-                self.hint = hint
-            }
-
-            var id: UUID
-            var word: String
-            var reading: String
-            var hint: String?
-
-            var nonNullHint: String {
-                get {
-                    hint ?? ""
-                }
-                set {
-                    if newValue.isEmpty {
-                        hint = nil
-                    } else {
-                        hint = newValue
-                    }
-                }
-            }
+            var items: [UserDictionaryEntry]
         }
 
         static let `default`: Value = .init(items: [
             .init(word: "azooKey", reading: "あずーきー", hint: "アプリ")
         ])
         static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.user_dictionary_temporal2"
+    }
+
+    struct SystemUserDictionary: CustomCodableConfigItem {
+        var items: Value = Self.default
+
+        struct Value: Codable {
+            var lastUpdate: Date?
+            var items: [UserDictionaryEntry]
+        }
+
+        static let `default`: Value = .init(items: [])
+        static let key: String = "dev.ensan.inputmethod.azooKeyMac.preference.system_user_dictionary"
     }
 }
 

--- a/azooKeyMac/InputController/SegmentsManager.swift
+++ b/azooKeyMac/InputController/SegmentsManager.swift
@@ -19,6 +19,9 @@ final class SegmentsManager {
     private var userDictionary: Config.UserDictionary.Value {
         Config.UserDictionary().value
     }
+    private var systemUserDictionary: Config.SystemUserDictionary.Value {
+        Config.SystemUserDictionary().value
+    }
     private var zenzaiPersonalizationLevel: Config.ZenzaiPersonalizationLevel.Value {
         Config.ZenzaiPersonalizationLevel().value
     }
@@ -329,10 +332,17 @@ final class SegmentsManager {
             return
         }
         // ユーザ辞書情報の更新
-        self.kanaKanjiConverter.sendToDicdataStore(.importDynamicUserDict(userDictionary.items.map {
+        var userDictionary: [DicdataElement] = userDictionary.items.map {
             .init(word: $0.word, ruby: $0.reading.toKatakana(), cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
-        }))
-        self.appendDebugMessage("userDictionaryCount: \(self.userDictionary.items.count)")
+        }
+        self.appendDebugMessage("userDictionaryCount: \(userDictionary.count)")
+        let systemUserDictionary: [DicdataElement] = systemUserDictionary.items.map {
+            .init(word: $0.word, ruby: $0.reading.toKatakana(), cid: CIDData.固有名詞.cid, mid: MIDData.一般.mid, value: -5)
+        }
+        self.appendDebugMessage("systemUserDictionaryCount: \(systemUserDictionary.count)")
+        userDictionary.append(contentsOf: consume systemUserDictionary)
+
+        self.kanaKanjiConverter.sendToDicdataStore(.importDynamicUserDict(consume userDictionary))
 
         let prefixComposingText = self.composingText.prefixToCursorPosition()
         let leftSideContext = forcedLeftSideContext ?? self.getCleanLeftSideContext(maxCount: 30)

--- a/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
+++ b/azooKeyMac/Windows/UserDictionaryEditorWindow.swift
@@ -12,7 +12,7 @@ struct UserDictionaryEditorWindow: View {
     @ConfigState private var userDictionary = Config.UserDictionary()
 
     @State private var editTargetID: UUID?
-    @State private var undoItem: Config.UserDictionary.Item?
+    @State private var undoItem: Config.UserDictionaryEntry?
 
     @ViewBuilder
     private func helpButton(helpContent: LocalizedStringKey, isPresented: Binding<Bool>) -> some View {
@@ -71,7 +71,7 @@ struct UserDictionaryEditorWindow: View {
                 HStack {
                     Spacer()
                     Button("追加", systemImage: "plus") {
-                        let newItem = Config.UserDictionary.Item(word: "", reading: "", hint: nil)
+                        let newItem = Config.UserDictionaryEntry(word: "", reading: "", hint: nil)
                         self.userDictionary.value.items.append(newItem)
                         self.editTargetID = newItem.id
                         self.undoItem = nil


### PR DESCRIPTION
resolve #182 

`~/Library/KeyboardServices`の位置にあるSQLite DBがシステムのユーザ辞書データであることがわかったので、これを取得して読み込む機能を追加した。

ただし、この位置にあるデータはデフォルトではアクセスできず、ユーザに明示的に選択してもらう必要がある。このため、設定画面内で「読み込む」ボタンを押した際にPanelが開き、そこでKeyboardServicesを選択すると読み込める、という設計を取った。

また、アクセス権を得たあとも、`sqlite3`のAPIを経由して読み込もうとすると様々なエラーが出たので、一旦`tmp`領域にデータをコピーし、その上で読み出している。

読み込み後はシステムユーザ辞書を通常の変換と併せて利用できる。