### PR TITLE
feat: AzooKeyKanaKanjiConverterの変更を取り入れ、破壊的変更に対処 / Zenzaiのパフォーマンスを大幅に改善

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", .upToNextMinor(from: "0.10.0"), traits: ["Zenzai"])
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "ee14c15ae9970c74a7a958aece64593ff1988141", traits: ["Zenzai"])
     ],
     targets: [
         .executableTarget(

--- a/azooKeyMac/AppDelegate.swift
+++ b/azooKeyMac/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     weak var userDictionaryEditorWindow: NSWindow?
     var configWindowController: NSWindowController?
     var userDictionaryEditorWindowController: NSWindowController?
-    @MainActor var kanaKanjiConverter = KanaKanjiConverter()
+    @MainActor var kanaKanjiConverter = KanaKanjiConverter.withDefaultDictionary()
 
     private static func buildSwiftUIWindow(
         _ view: some View,


### PR DESCRIPTION
このPRではAzooKeyKanaKanjiConverterの変更を取り入れ、破壊的変更に対処しています。

重要なものとしては**パフォーマンスの改善**が含まれます。以下の一連のPRで、Zenzai利用時の変換速度が大幅に改善しており、特に長文の入力時には実感を伴う性能向上になっています。
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/245
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/246
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/247
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/248
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/249
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/250
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/252
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/253

そのほかの変更詳細は以下で確認できます。
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/compare/v0.10.1...ee14c15ae9970c74a7a958aece64593ff1988141