### PR TITLE
refactor: OpenAIClientの実装をCore/側に移動

### DIFF
--- a/Core/Sources/Core/MagicConversion/OpenAIClient.swift
+++ b/Core/Sources/Core/MagicConversion/OpenAIClient.swift
@@ -182,7 +182,13 @@ private struct Prompt {
 //
 // - methods:
 //    - toJSON(): リクエストをOpenAI APIに適したJSON形式に変換する。
-struct OpenAIRequest {
+public struct OpenAIRequest {
+    public init(prompt: String, target: String, modelName: String) {
+        self.prompt = prompt
+        self.target = target
+        self.modelName = modelName
+    }
+
     let prompt: String
     let target: String
     let modelName: String
@@ -223,14 +229,14 @@ struct OpenAIRequest {
     }
 }
 
-enum OpenAIError: LocalizedError {
+public enum OpenAIError: LocalizedError, @unchecked Sendable {
     case invalidURL
     case noServerResponse
     case invalidResponseStatus(code: Int, body: String)
     case parseError(String)
     case invalidResponseStructure(Any)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidURL:
             return "Could not connect to OpenAI service. Please check your internet connection."
@@ -258,19 +264,10 @@ enum OpenAIError: LocalizedError {
 }
 
 // OpenAI APIクライアント
-enum OpenAIClient {
+public enum OpenAIClient {
     // APIリクエストを送信する静的メソッド
-    static func sendRequest(_ request: OpenAIRequest, apiKey: String, apiEndpoint: String? = nil, logger: ((String) -> Void)? = nil) async throws -> [String] {
-        let configEndpoint = Config.OpenAiApiEndpoint().value
-        let endpoint = if let apiEndpoint = apiEndpoint, !apiEndpoint.isEmpty {
-            apiEndpoint
-        } else if !configEndpoint.isEmpty {
-            configEndpoint
-        } else {
-            Config.OpenAiApiEndpoint.default
-        }
-
-        guard let url = URL(string: endpoint) else {
+    public static func sendRequest(_ request: OpenAIRequest, apiKey: String, apiEndpoint: String, logger: ((String) -> Void)? = nil) async throws -> [String] {
+        guard let url = URL(string: apiEndpoint) else {
             throw OpenAIError.invalidURL
         }
 
@@ -348,17 +345,8 @@ enum OpenAIClient {
     }
 
     // Simple text transformation method for AI Transform feature
-    static func sendTextTransformRequest(prompt: String, modelName: String, apiKey: String, apiEndpoint: String? = nil) async throws -> String {
-        let configEndpoint = Config.OpenAiApiEndpoint().value
-        let endpoint = if let apiEndpoint = apiEndpoint, !apiEndpoint.isEmpty {
-            apiEndpoint
-        } else if !configEndpoint.isEmpty {
-            configEndpoint
-        } else {
-            Config.OpenAiApiEndpoint.default
-        }
-
-        guard let url = URL(string: endpoint) else {
+    public static func sendTextTransformRequest(prompt: String, modelName: String, apiKey: String, apiEndpoint: String) async throws -> String {
+        guard let url = URL(string: apiEndpoint) else {
             throw OpenAIError.invalidURL
         }
 

--- a/azooKeyMac/InputController/azooKeyMacInputController+SelectedTextTransform.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController+SelectedTextTransform.swift
@@ -21,6 +21,14 @@ extension azooKeyMacInputController {
         let after: String
     }
 
+    private var endpoint: String {
+        if Config.OpenAiApiEndpoint().value.isEmpty {
+            Config.OpenAiApiEndpoint.default
+        } else {
+            Config.OpenAiApiEndpoint().value
+        }
+    }
+
     @MainActor
     func getContextAroundSelection(client: IMKTextInput, selectedRange: NSRange, contextLength: Int = Constants.defaultContextLength) -> TextContext {
         // Get the selected text
@@ -214,7 +222,7 @@ extension azooKeyMacInputController {
                     prompt: systemPrompt,
                     modelName: modelName,
                     apiKey: apiKey,
-                    apiEndpoint: Config.OpenAiApiEndpoint().value
+                    apiEndpoint: self.endpoint
                 )
 
                 await MainActor.run {
@@ -382,7 +390,7 @@ extension azooKeyMacInputController {
             prompt: systemPrompt,
             modelName: modelName,
             apiKey: apiKey,
-            apiEndpoint: Config.OpenAiApiEndpoint().value
+            apiEndpoint: self.endpoint
         )
 
         await MainActor.run {

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -75,11 +75,15 @@ struct ConfigWindow: View {
                 target: "",
                 modelName: openAiModelName.value.isEmpty ? Config.OpenAiModelName.default : openAiModelName.value
             )
-
+            let endpoint = if !openAiApiEndpoint.value.isEmpty {
+                openAiApiEndpoint.value
+            } else {
+                Config.OpenAiApiEndpoint.default
+            }
             _ = try await OpenAIClient.sendRequest(
                 testRequest,
                 apiKey: openAiApiKey.value,
-                apiEndpoint: openAiApiEndpoint.value
+                apiEndpoint: endpoint
             )
 
             connectionTestResult = "接続成功"


### PR DESCRIPTION
#170 で言及した2ステップの1つ目。`Core/`に`OpenAIClient`の実装を移動し、再利用性を高める。