### PR TITLE
fix: デッドキー+数字キーの振る舞い

### DIFF
--- a/Core/Sources/Core/InputUtils/InputState.swift
+++ b/Core/Sources/Core/InputUtils/InputState.swift
@@ -109,6 +109,8 @@ public enum InputState: Sendable, Hashable {
                 }
             case .deadKey(let newDiacritic):
                 return (.insertWithoutMarkedText(diacritic), .transition(.attachDiacritic(newDiacritic)))
+            case .number(let number):
+                return (.insertWithoutMarkedText(diacritic + number.inputString), .transition(.none))
             case .backspace, .escape:
                 return (.stopComposition, .transition(.none))
             case .かな:
@@ -119,7 +121,7 @@ public enum InputState: Sendable, Hashable {
                 return (.insertWithoutMarkedText(diacritic + "\n"), .transition(.none))
             case .tab:
                 return (.insertWithoutMarkedText(diacritic + "\t"), .transition(.none))
-            case .unknown, .number, .space, .英数, .navigation, .editSegment, .suggest, .forget, .transformSelectedText:
+            case .unknown, .space, .英数, .navigation, .editSegment, .suggest, .forget, .transformSelectedText:
                 return (.insertWithoutMarkedText(diacritic), .transition(.none))
             }
         case .composing:


### PR DESCRIPTION
デッドキー入力後に数字キーを入力したときの振る舞いを修正しました。
従来は `¨` のみが入力されていましたが、この修正で `¨1` と入力されるようになります。