### PR TITLE
fix: ターミナルで最初の1文字が二重に入力される問題を修正

### DIFF
--- a/Core/Sources/Core/XPC/ConverterClientEventRouter.swift
+++ b/Core/Sources/Core/XPC/ConverterClientEventRouter.swift
@@ -56,13 +56,41 @@ public enum ConverterClientEventRouter {
             return .sendToServer
         }
 
-        let inputState = context.acknowledgedInputState.inputState
+        if case .fallthrough = Self.clientAction(event: event, context: context) {
+            return .fallthroughToApplication
+        }
+        return .sendToServer
+    }
+
+    /// Server の応答を待つ間、application へ同期的に置く暫定の marked text
+    /// 未確定文字列が無い状態の最初の文字が生のキーとして漏れるのを防ぐ。
+    public static func provisionalMarkedText(
+        event: KeyEventCore,
+        context: ConverterClientEventRoutingContext
+    ) -> String? {
+        guard context.acknowledgedInputState == .none else {
+            return nil
+        }
+        switch Self.clientAction(event: event, context: context) {
+        case .appendPieceToMarkedText(let pieces):
+            return pieces.inputString(preferIntention: false)
+        case .insertWithoutMarkedText(let text):
+            return text
+        default:
+            return nil
+        }
+    }
+
+    private static func clientAction(
+        event: KeyEventCore,
+        context: ConverterClientEventRoutingContext
+    ) -> ClientAction {
         let userAction = UserAction.getUserAction(
             eventCore: event,
             inputLanguage: context.acknowledgedInputLanguage,
             typeBackSlash: context.typeBackSlash
         )
-        let (action, _) = inputState.event(
+        let (action, _) = context.acknowledgedInputState.inputState.event(
             eventCore: event,
             userAction: userAction,
             inputLanguage: context.acknowledgedInputLanguage,
@@ -70,9 +98,6 @@ public enum ConverterClientEventRouter {
             enableDebugWindow: context.enableDebugWindow,
             enableSuggestion: context.enableSuggestion
         )
-        if case .fallthrough = action {
-            return .fallthroughToApplication
-        }
-        return .sendToServer
+        return action
     }
 }

--- a/Core/Tests/CoreTests/XPCTests/ConverterClientEventRouterTests.swift
+++ b/Core/Tests/CoreTests/XPCTests/ConverterClientEventRouterTests.swift
@@ -83,3 +83,68 @@ private func disposition(
     #expect(disposition(event: event) == .fallthroughToApplication)
     #expect(disposition(event: event, state: .composing) == .sendToServer)
 }
+
+private func provisionalMarkedText(
+    event: KeyEventCore,
+    state: ConverterInputState = .none,
+    language: InputLanguage = .japanese,
+    hasPendingKeyEvents: Bool = false
+) -> String? {
+    ConverterClientEventRouter.provisionalMarkedText(
+        event: event,
+        context: .init(
+            acknowledgedInputState: state,
+            acknowledgedInputLanguage: language,
+            hasPendingKeyEvents: hasPendingKeyEvents
+        )
+    )
+}
+
+private let letterB = KeyEventCore(
+    modifierFlags: [],
+    characters: "b",
+    charactersIgnoringModifiers: "b",
+    keyCode: 11
+)
+
+@Test func firstCharacterIsPlacedAsProvisionalMarkedText() {
+    #expect(provisionalMarkedText(event: letterB) == "b")
+    #expect(provisionalMarkedText(event: letterB, language: .english) == "b")
+}
+
+@Test func provisionalMarkedTextKeepsRawKeyForKanaInput() {
+    // かな入力の変換は Server の入力テーブルが行うため、Client は生のキーを置く
+    let event = KeyEventCore(
+        modifierFlags: [],
+        characters: "r",
+        charactersIgnoringModifiers: "r",
+        keyCode: 15
+    )
+    #expect(provisionalMarkedText(event: event) == "r")
+}
+
+@Test func provisionalMarkedTextIsAccumulatedWhileEarlierKeyEventIsPending() {
+    // acknowledged state が古くても文字は返す。積み上げは Client が行う
+    #expect(provisionalMarkedText(event: letterB, hasPendingKeyEvents: true) == "b")
+}
+
+@Test func provisionalMarkedTextIsNotPlacedDuringComposition() {
+    #expect(provisionalMarkedText(event: letterB, state: .composing) == nil)
+}
+
+@Test func provisionalMarkedTextIsNotPlacedForNonInputKeys() {
+    let backspace = KeyEventCore(
+        modifierFlags: [],
+        characters: nil,
+        charactersIgnoringModifiers: nil,
+        keyCode: 51
+    )
+    let commandShortcut = KeyEventCore(
+        modifierFlags: [.command],
+        characters: "c",
+        charactersIgnoringModifiers: "c",
+        keyCode: 8
+    )
+    #expect(provisionalMarkedText(event: backspace) == nil)
+    #expect(provisionalMarkedText(event: commandShortcut) == nil)
+}

--- a/azooKeyMac/InputController/azooKeyMacInputController.swift
+++ b/azooKeyMac/InputController/azooKeyMacInputController.swift
@@ -9,6 +9,8 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     private(set) var inputState: InputState = .none
     private var inputLanguage: InputLanguage = .japanese
     private var pendingKeyEventCount = 0
+    /// Server の応答を待つ間、application に置いている暫定の marked text
+    private var provisionalMarkedText = ""
     private var nextKeyEventID: UInt64 = 0
     private var activationGeneration: UInt64 = 0
     private var pendingConverterServerActivation: ConverterSessionActivation?
@@ -178,6 +180,7 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
         self.pendingConverterServerActivation = nil
         self.converterServerClient.sendIfSessionOpen({ _ in .lifecycle(.deactivate) }, completion: { _ in })
         self.currentConverterView = nil
+        self.provisionalMarkedText = ""
         self.inputState = .none
         self.candidatesWindow.orderOut(nil)
         self.predictionWindow.orderOut(nil)
@@ -335,20 +338,28 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
         enableSuggestion: Bool,
         optionDirectInputText: String? = nil
     ) -> Bool {
-        let disposition = ConverterClientEventRouter.disposition(
-            event: event,
-            context: .init(
-                acknowledgedInputState: ConverterInputState(self.inputState),
-                acknowledgedInputLanguage: self.inputLanguage,
-                hasPendingKeyEvents: self.pendingKeyEventCount > 0,
-                liveConversionEnabled: Config.LiveConversion().value,
-                enableDebugWindow: Config.DebugWindow().value,
-                enableSuggestion: enableSuggestion,
-                typeBackSlash: Config.TypeBackSlash().value
-            )
+        let routingContext = ConverterClientEventRoutingContext(
+            acknowledgedInputState: ConverterInputState(self.inputState),
+            acknowledgedInputLanguage: self.inputLanguage,
+            hasPendingKeyEvents: self.pendingKeyEventCount > 0,
+            liveConversionEnabled: Config.LiveConversion().value,
+            enableDebugWindow: Config.DebugWindow().value,
+            enableSuggestion: enableSuggestion,
+            typeBackSlash: Config.TypeBackSlash().value
         )
-        guard disposition == .sendToServer else {
+        guard ConverterClientEventRouter.disposition(event: event, context: routingContext) == .sendToServer else {
             return false
+        }
+        // 応答が届く前に `handle` が返るため、未確定文字列が無い状態で送る文字は
+        // ここで marked text にしておかないと application (e.g. iTerm2) へ生のキーが漏れる。
+        if let text = ConverterClientEventRouter.provisionalMarkedText(event: event, context: routingContext) {
+            self.provisionalMarkedText += text
+            self.setMarkedText(
+                ConverterMarkedText(
+                    elements: [.init(content: self.provisionalMarkedText, focus: .unfocused)],
+                    selectionRange: ConverterRange(location: self.provisionalMarkedText.count, length: 0)
+                )
+            )
         }
 
         self.nextKeyEventID &+= 1
@@ -718,6 +729,11 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
     }
 
     func refreshMarkedText() {
+        self.provisionalMarkedText = ""
+        self.setMarkedText(self.currentMarkedText())
+    }
+
+    private func setMarkedText(_ markedText: ConverterMarkedText) {
         let highlight = self.mark(
             forStyle: kTSMHiliteSelectedConvertedText,
             at: NSRange(location: NSNotFound, length: 0)
@@ -727,8 +743,7 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
             at: NSRange(location: NSNotFound, length: 0)
         ) as? [NSAttributedString.Key: Any]
         let text = NSMutableAttributedString(string: "")
-        let currentMarkedText = self.currentMarkedText()
-        for part in currentMarkedText.elements where !part.content.isEmpty {
+        for part in markedText.elements where !part.content.isEmpty {
             let attributes: [NSAttributedString.Key: Any]? = switch part.focus {
             case .focused: highlight
             case .unfocused: underline
@@ -743,7 +758,7 @@ class azooKeyMacInputController: IMKInputController, NSMenuItemValidation { // s
         }
         self.client()?.setMarkedText(
             text,
-            selectionRange: currentMarkedText.selectionRange.nsRange,
+            selectionRange: markedText.selectionRange.nsRange,
             replacementRange: NSRange(location: NSNotFound, length: 0)
         )
     }


### PR DESCRIPTION
Closes #357 

## 修正

未確定文字列が無い状態で文字キーが押されたら、変換結果を待たずに、押された文字をそのまま暫定の未確定文字列として表示する。変換結果が届いたら本来の内容に置き換える。

- `ConverterClientEventRouter.provisionalMarkedText(event:context:)` を追加。暫定の未確定文字列を表示するかどうか、表示するなら何を表示するかをここで判定する
- `azooKeyMacInputController` は、変換結果が返るまでに押された文字を暫定の未確定文字列として表示し (通常は 1 文字。結果より先に次のキーが来たときだけ 2 文字以上になる)、結果が届いた `refreshMarkedText()` で本来の内容に置き換える。入力元のアプリが切り替わる `deactivateServer` でも暫定の文字列は捨てる
- `refreshMarkedText()` から `setMarkedText(_:)` を分け、暫定と本番で同じ経路を使う

## 注意点

暫定の未確定文字列には押されたキーの文字をそのまま使うため、変換結果が届くまでの 30〜110ms のあいだ、本来と違う文字が見えることがある。

- かな入力: `r` を押すと下線付きの `r` が一瞬見えてから `す` になる
- 英字モード (英数キーで切り替わる方): 確定される `a` が一瞬だけ下線付きで見える
- 全角スペース: 半角スペースが一瞬見えてから全角になる

## 確認

- Core `swift test` 72 件 passした
  - `provisionalMarkedText` の判定にテストを 5 件追加した
- `swiftlint --strict` pass
- iTerm2 で `b` が 1 文字だけ入るか、かな入力 (JIS) で `r` → `す` になるか、Alfred など通常の text view でも問題ないかチェックした
