### PR TITLE
fix: 入力方式で「カスタム」を選んでも既定のローマ字入力のままになる問題を修正

### DIFF
--- a/Core/Sources/Core/Configs/CustomInputTableStore.swift
+++ b/Core/Sources/Core/Configs/CustomInputTableStore.swift
@@ -12,12 +12,29 @@ public enum CustomInputTableStore {
     private static let fileName = "custom_input_table.tsv"
 
     static var directoryURL: URL {
+        #if os(macOS)
+        return AppGroup.applicationSupportDirectoryURL()
+            .appendingPathComponent(directoryName, isDirectory: true)
+        #else
+        return legacyDirectoryURL
+        #endif
+    }
+
+    private static var legacyDirectoryURL: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return base.appendingPathComponent(appSupportSubdir, isDirectory: true)
             .appendingPathComponent(directoryName, isDirectory: true)
     }
 
-    static var fileURL: URL {
+    public static var fileURL: URL {
+        fileURL(in: directoryURL)
+    }
+
+    public static var legacyFileURL: URL {
+        fileURL(in: legacyDirectoryURL)
+    }
+
+    private static func fileURL(in directoryURL: URL) -> URL {
         #if canImport(UniformTypeIdentifiers) && !os(Linux)
         return directoryURL.appendingPathComponent(fileName, conformingTo: .text)
         #else

--- a/azooKeyMac/Windows/ConfigWindow.swift
+++ b/azooKeyMac/Windows/ConfigWindow.swift
@@ -91,6 +91,14 @@ struct ConfigWindow: View {
         )
     }
 
+    private var customInputTableFileURL: URL {
+        CustomInputTableStore.fileURL
+    }
+
+    private var legacyCustomInputTableFileURL: URL {
+        CustomInputTableStore.legacyFileURL
+    }
+
     private var debugTypoCorrectionStatusText: String {
         if self.debugTypoCorrectionDownloadInProgress {
             return "ダウンロード中..."
@@ -188,6 +196,18 @@ struct ConfigWindow: View {
     }
 
     @MainActor
+    private func migrateCustomInputTableIfNeeded() async {
+        let fileURL = self.customInputTableFileURL
+        let legacyFileURL = self.legacyCustomInputTableFileURL
+        await Task.detached(priority: .utility) {
+            Self.migrateLegacyCustomInputTableIfNeeded(
+                from: legacyFileURL,
+                to: fileURL
+            )
+        }.value
+    }
+
+    @MainActor
     private func downloadDebugTypoCorrectionWeights() {
         guard !self.debugTypoCorrectionDownloadInProgress else {
             return
@@ -237,6 +257,26 @@ struct ConfigWindow: View {
             try fileManager.copyItem(at: sourceURL, to: targetURL)
         } catch {
             // The status check below will surface a notDownloaded/failed state.
+        }
+    }
+
+    nonisolated private static func migrateLegacyCustomInputTableIfNeeded(from sourceURL: URL, to targetURL: URL) {
+        guard sourceURL.standardizedFileURL != targetURL.standardizedFileURL else {
+            return
+        }
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: targetURL.path),
+              fileManager.fileExists(atPath: sourceURL.path) else {
+            return
+        }
+        do {
+            try fileManager.createDirectory(
+                at: targetURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try fileManager.copyItem(at: sourceURL, to: targetURL)
+        } catch {
+            // The converter falls back to the default input style until the table is copied.
         }
     }
 
@@ -804,6 +844,21 @@ struct ConfigWindow: View {
                     Text("かな入力（US）").tag(Config.InputStyle.Value.defaultKanaUS)
                     Text("AZIK").tag(Config.InputStyle.Value.defaultAZIK)
                     Text("カスタム").tag(Config.InputStyle.Value.custom)
+                }
+                .onAppear {
+                    guard self.inputStyle.value == .custom else {
+                        return
+                    }
+                    Task { @MainActor in
+                        await self.migrateCustomInputTableIfNeeded()
+                    }
+                }
+                .onChange(of: self.inputStyle.value) { value in
+                    if value == .custom {
+                        Task { @MainActor in
+                            await self.migrateCustomInputTableIfNeeded()
+                        }
+                    }
                 }
                 if inputStyle.value == .custom {
                     LabeledContent {


### PR DESCRIPTION
Closes #359 

## 修正

カスタム入力テーブルの保存先を、sandbox の内外どちらからも見える App Group の共有コンテナに変える。

- `CustomInputTableStore.directoryURL` を `AppGroup.applicationSupportDirectoryURL()` の下 (`…/Group Containers/group.dev.ensan.inputmethod.azooKeyMac/Library/Application Support/azooKey/CustomInputTable/`) にする。macOS 以外は従来のまま
- 設定画面で入力方式が「カスタム」のとき、旧保存先 (sandbox の container 内) に表があり、新しい保存先に無ければコピーする (`ConfigWindow.migrateLegacyCustomInputTableIfNeeded`)。旧保存先の file は残す

保存先の決め方とコピーの手順は、typo correction の重み (`ConfigWindow.migrateLegacyDebugTypoCorrectionWeightsIfNeeded`) と同じ形にした。(ほぼ真似しました)
こちらは既に App Group の共有コンテナに保存し、旧保存先に残っている重みを設定画面を開いたときにコピーしている。

## 確認

- Core `swift test` pass
- `swiftlint --strict` pass
- 手元で確認: 旧保存先にカスタム入力テーブルがある状態で設定画面を開くと (入力方式は「カスタム」)、新しい保存先に同じ内容のカスタム入力テーブルがコピーされ、テーブルどおりに入力できた (JIS かな配列のテーブルで `r` → `す`)
