### PR TITLE
fix: 予測候補を Tab で受け入れても、窓に出ていた候補が無視される問題を修正

### DIFF
--- a/Core/Sources/ConverterServer/ConverterServer+KeyEvent.swift
+++ b/Core/Sources/ConverterServer/ConverterServer+KeyEvent.swift
@@ -373,6 +373,10 @@ extension ConverterServer {
         guard !prediction.appendText.isEmpty else {
             return
         }
+        if let candidate = prediction.candidate {
+            // 読みを補完する前に伝える。補完後の再変換で候補の表記が先頭の制約になる
+            manager.acceptPredictionCandidate(candidate)
+        }
         manager.insertAtCursorPosition(prediction.appendText, inputStyle: .direct)
     }
 }

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -65,6 +65,8 @@ public final class SegmentsManager {
         public var displayText: String
         public var appendText: String
         public var deleteCount: Int = 0
+        /// 表示のもとになった変換器の候補。受け入れたことを変換器へ伝えるのに使う
+        public var candidate: Candidate?
     }
 
     struct BackspaceTypoCorrectionLock: Sendable {
@@ -861,6 +863,11 @@ public final class SegmentsManager {
         return [backspaceAdjustedPredictionCandidate]
     }
 
+    /// 予測候補を受け入れたことを変換器へ伝える。以降の変換では、その候補の表記が先頭の制約になる
+    public func acceptPredictionCandidate(_ candidate: Candidate) {
+        self.kanaKanjiConverter.setPrefixCandidate(candidate)
+    }
+
     public static func preferredPredictionCandidates(
         typoCorrectionCandidates: [PredictionCandidate],
         predictionCandidates: [PredictionCandidate]
@@ -898,11 +905,12 @@ public final class SegmentsManager {
             guard !reading.isEmpty else {
                 continue
             }
-            if let predictionCandidate = Self.makePredictionCandidate(
+            if var predictionCandidate = Self.makePredictionCandidate(
                 currentTarget: target,
                 candidateReading: reading,
                 displayText: candidate.text
             ) {
+                predictionCandidate.candidate = candidate
                 return [predictionCandidate]
             }
         }


### PR DESCRIPTION
Closes #361 

## 修正

Tab を押したとき、その時点で窓に出ていた候補の表記を `SegmentsManager` が覚えておき、marked text を決めるときにそれを使う。

- `SegmentsManager.acceptedPredictionDisplayText` に、Tab を押した時点で窓に出ていた候補の `displayText` を持つ
- `getCurrentMarkedText` で、この値があればライブ変換の第一候補より優先して表示する。Enter で確定されるのもこの表記になる
- `lastOperation` の `didSet` で値を捨てる。次の入力・削除・文節編集が起きた時点で固定が外れる
- 候補を適用する処理 (`deleteCount` 分の削除と `appendText` の挿入) を `ConverterServer+KeyEvent` から `SegmentsManager.acceptPredictionCandidate` へ移し、表記を覚えるのと同じ場所で行う

## 確認

- Core `swift test` pass
- `swiftlint --strict` pass
- 手元で確認: 「開発中の予測入力を有効化」ON で `ひだ` と打ち、予測候補の窓に `←` が出た状態で Tab を押すと、変換中テキストが `←` になり、Enter で `←` が確定された

