### PR TITLE
数字の区切り記号と中黒にピリオド・スラッシュ候補を追加する

### DIFF
--- a/Core/Sources/Core/InputUtils/NumericSeparatorCandidates.swift
+++ b/Core/Sources/Core/InputUtils/NumericSeparatorCandidates.swift
@@ -1,0 +1,39 @@
+enum NumericSeparatorCandidates {
+    /// 数字の区切りと単独の中黒に、記号の別表記を追加する。
+    static func variants(for reading: String) -> [String] {
+        if reading == "・" {
+            return ["/", "／"]
+        }
+        let separator: Character
+        let replacement: String
+        if reading.contains("。") {
+            separator = "。"
+            replacement = "."
+        } else if reading.contains("・") {
+            separator = "・"
+            replacement = "/"
+        } else {
+            return []
+        }
+        let groups = reading.split(separator: separator, omittingEmptySubsequences: false)
+        var normalized: [String] = []
+        for group in groups {
+            guard !group.isEmpty else {
+                return []
+            }
+            var digits = ""
+            for scalar in group.unicodeScalars {
+                switch scalar.value {
+                case 0x30...0x39:
+                    digits.unicodeScalars.append(scalar)
+                case 0xFF10...0xFF19:
+                    digits.unicodeScalars.append(UnicodeScalar(scalar.value - 0xFEE0)!)
+                default:
+                    return []
+                }
+            }
+            normalized.append(digits)
+        }
+        return [normalized.joined(separator: replacement)]
+    }
+}

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -574,18 +574,21 @@ public final class SegmentsManager {
                 requireEnglishPrediction: Config.DebugPredictiveTyping().value ? .manualMix : .disabled
             )
         )
-        let separatorTexts = Set(result.mainResults.map(\.text))
-        let separatorCandidates = NumericSeparatorCandidates.variants(for: self.composingText.convertTarget)
-            .filter { !separatorTexts.contains($0) }.map { text in
+        let separatorInput = self.composingText.prefixToCursorPosition()
+        let separatorVariants = NumericSeparatorCandidates.variants(for: separatorInput.convertTarget)
+        if !separatorVariants.isEmpty {
+            let separatorTexts = Set(result.mainResults.map(\.text))
+            let separatorCandidates = separatorVariants.filter { !separatorTexts.contains($0) }.map { text in
                 Candidate(
                     text: text, value: -18,
-                    composingCount: .inputCount(self.composingText.input.count),
+                    composingCount: .inputCount(separatorInput.input.count),
                     lastMid: MIDData.一般.mid,
-                    data: [.init(word: text, ruby: self.composingText.convertTarget.toKatakana(), cid: CIDData.記号.cid, mid: MIDData.一般.mid, value: -18)],
+                    data: [.init(word: text, ruby: separatorInput.convertTarget.toKatakana(), cid: CIDData.記号.cid, mid: MIDData.一般.mid, value: -18)],
                     isLearningTarget: false
                 )
             }
-        result.mainResults.insert(contentsOf: separatorCandidates, at: min(5, result.mainResults.count))
+            result.mainResults.insert(contentsOf: separatorCandidates, at: min(5, result.mainResults.count))
+        }
         self.rawCandidates = result
     }
 

--- a/Core/Sources/Core/InputUtils/SegmentsManager.swift
+++ b/Core/Sources/Core/InputUtils/SegmentsManager.swift
@@ -564,7 +564,7 @@ public final class SegmentsManager {
 
         let leftSideContext = forcedLeftSideContext ?? self.getCleanLeftSideContext(maxCount: ContextLength.conversion)
         let rightSideContext = forcedRightSideContext ?? self.getCleanRightSideContext(maxCount: ContextLength.conversion)
-        let result = self.kanaKanjiConverter.requestCandidates(
+        var result = self.kanaKanjiConverter.requestCandidates(
             self.composingText,
             options: options(
                 leftSideContext: leftSideContext,
@@ -574,6 +574,18 @@ public final class SegmentsManager {
                 requireEnglishPrediction: Config.DebugPredictiveTyping().value ? .manualMix : .disabled
             )
         )
+        let separatorTexts = Set(result.mainResults.map(\.text))
+        let separatorCandidates = NumericSeparatorCandidates.variants(for: self.composingText.convertTarget)
+            .filter { !separatorTexts.contains($0) }.map { text in
+                Candidate(
+                    text: text, value: -18,
+                    composingCount: .inputCount(self.composingText.input.count),
+                    lastMid: MIDData.一般.mid,
+                    data: [.init(word: text, ruby: self.composingText.convertTarget.toKatakana(), cid: CIDData.記号.cid, mid: MIDData.一般.mid, value: -18)],
+                    isLearningTarget: false
+                )
+            }
+        result.mainResults.insert(contentsOf: separatorCandidates, at: min(5, result.mainResults.count))
         self.rawCandidates = result
     }
 

--- a/Core/Tests/CoreTests/InputUtilsTests/EditedVariantRangeTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/EditedVariantRangeTests.swift
@@ -1,0 +1,23 @@
+import Core
+import Foundation
+import KanaKanjiConverterModuleWithDefaultDictionary
+import Testing
+
+@MainActor
+@Test func editedVariantConsumesOnlySelectedPrefix() throws {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let manager = SegmentsManager(kanaKanjiConverter: .withDefaultDictionary(), applicationDirectoryURL: directory,
+                                  containerURL: nil, context: .init(useZenzai: false))
+    manager.insertAtCursorPosition("10・10", inputStyle: .direct)
+    manager.editSegment(count: -1)
+    manager.requestSetCandidateWindowState(visible: true)
+    guard case .selecting(let choices, _) = manager.getCurrentCandidateWindow(inputState: .selecting) else {
+        Issue.record("Expected candidates for edited segment")
+        return
+    }
+    let candidate = try #require(choices.first { $0.text == "10/1" })
+    manager.prefixCandidateCommited(candidate, leftSideContext: "")
+    #expect(manager.convertTarget == "0")
+}

--- a/Core/Tests/CoreTests/InputUtilsTests/NumericSeparatorCandidatesTests.swift
+++ b/Core/Tests/CoreTests/InputUtilsTests/NumericSeparatorCandidatesTests.swift
@@ -1,0 +1,47 @@
+@testable import Core
+import Foundation
+import KanaKanjiConverterModuleWithDefaultDictionary
+import Testing
+
+@MainActor
+struct NumericSeparatorCandidatesTests {
+    @Test func numericGroupsAndStandaloneMiddleDot() {
+        #expect(NumericSeparatorCandidates.variants(for: "5。1") == ["5.1"])
+        #expect(NumericSeparatorCandidates.variants(for: "５。１") == ["5.1"])
+        #expect(NumericSeparatorCandidates.variants(for: "10・10") == ["10/10"])
+        #expect(NumericSeparatorCandidates.variants(for: "２０２６・9・05") == ["2026/9/05"])
+        #expect(NumericSeparatorCandidates.variants(for: "1。2。3") == ["1.2.3"])
+        #expect(NumericSeparatorCandidates.variants(for: "・") == ["/", "／"])
+        for input in ["", "。", "5。", "。1", "10・・10", "1。2・3", "文章。", "名前・名前", "10/10", "5.1", "１０", "5 。1"] {
+            #expect(NumericSeparatorCandidates.variants(for: input).isEmpty)
+        }
+    }
+
+    @Test(arguments: [("5。1", "5.1"), ("10・10", "10/10"), ("・", "/"), ("・", "／"), ("５。１", "5.1")])
+    func candidatesPreserveInputAndCommitWholeValue(input: String, expected: String) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let manager = SegmentsManager(kanaKanjiConverter: .withDefaultDictionary(), applicationDirectoryURL: directory,
+                                      containerURL: nil, context: .init(useZenzai: false))
+        manager.insertAtCursorPosition(input, inputStyle: .direct)
+        for rich in [false, true] {
+            manager.update(requestRichCandidates: rich)
+            manager.requestSetCandidateWindowState(visible: true)
+            guard case .selecting(let choices, _) = manager.getCurrentCandidateWindow(inputState: .selecting) else {
+                Issue.record("Expected conversion candidates")
+                return
+            }
+            #expect(manager.convertTarget == input)
+            #expect(choices.contains { $0.text == input })
+            #expect(choices.filter { $0.text == expected }.count == 1)
+            if rich {
+                let row = try #require(choices.firstIndex { $0.text == expected })
+                manager.requestSelectingRow(row)
+                let candidate = try #require(manager.selectedCandidate)
+                manager.prefixCandidateCommited(candidate, leftSideContext: "")
+                #expect(manager.isEmpty)
+            }
+        }
+    }
+}


### PR DESCRIPTION
5。1→5.1、10・10→10/10、単独の・→/と／を候補へ追加します。数字の全角・半角に対応し、文章中の句点や中黒は対象外です。

## 検証

不正な区切り・文章の除外・元候補維持・重複・全体確定をテスト。

このブランチ単独で `swift test --package-path Core --jobs 4` を実行し、Coreの70テストが成功しました。`git diff --check` も成功しています。

検証は各ブランチ単独で実施しています。並行実行時に既存の設定共有テストが一度失敗したため、単独再実行で成功を確認しました。

## 変換範囲と処理負荷

文節編集中は選択中の範囲だけから候補を作り、その範囲だけを確定します。残りの文字は未確定で保持します。候補が空の場合の重複チェックは省略します。
